### PR TITLE
Added sgemm sup kernels for zen architecture

### DIFF
--- a/config/zen3/bli_cntx_init_zen3.c
+++ b/config/zen3/bli_cntx_init_zen3.c
@@ -62,10 +62,6 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	  BLIS_GEMMTRSM_U_UKR, BLIS_FLOAT,    bli_sgemmtrsm_u_haswell_asm_6x16,
 	  BLIS_GEMMTRSM_U_UKR, BLIS_DOUBLE,   bli_dgemmtrsm_u_haswell_asm_6x8,
 
-	  // gemmsup
-#if 0
-	  // AMD: This should be enabled in the PR which has added these kernels
-	  // Update the context with optimized small/unpacked gemm kernels.
 	  BLIS_GEMMSUP_RRR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8m,
 	  BLIS_GEMMSUP_RRC_UKR, BLIS_DOUBLE, bli_dgemmsup_rd_haswell_asm_6x8m,
 	  BLIS_GEMMSUP_RCR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8m,
@@ -82,37 +78,6 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	  BLIS_GEMMSUP_CRC_UKR, BLIS_FLOAT, bli_sgemmsup_rd_zen_asm_6x16n,
 	  BLIS_GEMMSUP_CCR_UKR, BLIS_FLOAT, bli_sgemmsup_rv_zen_asm_6x16n,
 	  BLIS_GEMMSUP_CCC_UKR, BLIS_FLOAT, bli_sgemmsup_rv_zen_asm_6x16n,
-	  BLIS_GEMMSUP_RRR_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8m,
-	  BLIS_GEMMSUP_RCR_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8m,
-	  BLIS_GEMMSUP_CRR_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8m,
-	  BLIS_GEMMSUP_RCC_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8n,
-	  BLIS_GEMMSUP_CCR_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8n,
-	  BLIS_GEMMSUP_CCC_UKR, BLIS_SCOMPLEX, bli_cgemmsup_rv_zen_asm_3x8n,
-	  BLIS_GEMMSUP_RRR_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4m,
-	  BLIS_GEMMSUP_RCR_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4m,
-	  BLIS_GEMMSUP_CRR_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4m,
-	  BLIS_GEMMSUP_RCC_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4n,
-	  BLIS_GEMMSUP_CCR_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4n,
-	  BLIS_GEMMSUP_CCC_UKR, BLIS_DCOMPLEX, bli_zgemmsup_rv_zen_asm_3x4n,
-#else
-	  BLIS_GEMMSUP_RRR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8m,
-	  BLIS_GEMMSUP_RRC_UKR, BLIS_DOUBLE, bli_dgemmsup_rd_haswell_asm_6x8m,
-	  BLIS_GEMMSUP_RCR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8m,
-	  BLIS_GEMMSUP_RCC_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8n,
-	  BLIS_GEMMSUP_CRR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8m,
-	  BLIS_GEMMSUP_CRC_UKR, BLIS_DOUBLE, bli_dgemmsup_rd_haswell_asm_6x8n,
-	  BLIS_GEMMSUP_CCR_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8n,
-	  BLIS_GEMMSUP_CCC_UKR, BLIS_DOUBLE, bli_dgemmsup_rv_haswell_asm_6x8n,
-
-	  BLIS_GEMMSUP_RRR_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16m,
-	  BLIS_GEMMSUP_RRC_UKR, BLIS_FLOAT, bli_sgemmsup_rd_haswell_asm_6x16m,
-	  BLIS_GEMMSUP_RCR_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16m,
-	  BLIS_GEMMSUP_RCC_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16n,
-	  BLIS_GEMMSUP_CRR_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16m,
-	  BLIS_GEMMSUP_CRC_UKR, BLIS_FLOAT, bli_sgemmsup_rd_haswell_asm_6x16n,
-	  BLIS_GEMMSUP_CCR_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16n,
-	  BLIS_GEMMSUP_CCC_UKR, BLIS_FLOAT, bli_sgemmsup_rv_haswell_asm_6x16n,
-#endif
 
 	  // packm
 #if 0
@@ -232,18 +197,18 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	//                                           s      d      c      z
 	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     6,     6,     3,     3 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    16,     8,     8,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   144,    72,    72,    36 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   256 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,  4080 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   144,    72,   144,    18 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   566 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,   256 );
 
 	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     5,     5,    -1,    -1 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );
 
 	// Initialize sup thresholds with architecture-appropriate values.
 	//                                          s     d     c     z
-	bli_blksz_init_easy( &blkszs[ BLIS_MT ],  512,  256,   -1,   -1 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NT ],  200,  256,   -1,   -1 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KT ],  240,  220,   -1,   -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MT ],  512,  256,   380,  110 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NT ],  200,  256,   256,   128 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KT ],  240,  220,   220,   110 );
 
 	// Initialize level-3 sup blocksize objects with architecture-specific
 	// values.
@@ -251,9 +216,9 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	bli_blksz_init     ( &blkszs[ BLIS_MR_SUP ],     6,     6,     3,     3,
 	                                                 9,     9,     3,     3 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NR_SUP ],    16,     8,     8,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC_SUP ],   144,    72,    72,    36 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC_SUP ],   512,   256,   128,    64 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC_SUP ],  8160,  4080,  2040,  1020 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC_SUP ],   144,    72,    144,    24 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC_SUP ],   256,   492,   256,    512 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC_SUP ],  4080,  1600,  4080,  1536 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.
@@ -289,17 +254,5 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 
 	// -------------------------------------------------------------------------
 
-#if 0
-	// Initialize the context with the sup handlers.
-	bli_cntx_set_l3_sup_handlers
-	(
-	  cntx,
-
-	  BLIS_GEMM, bli_gemmsup_ref,
-	  //BLIS_GEMMT, bli_gemmtsup_ref,
-
-	  BLIS_VA_END
-	);
-#endif
 }
 

--- a/frame/include/bli_x86_asm_macros.h
+++ b/frame/include/bli_x86_asm_macros.h
@@ -915,7 +915,7 @@
 #define VCOMISD(_0, _1) INSTR_(vcomisd, _0, _1)
 
 #define VMASKMOVPD(_0, _1, _2) INSTR_(vmaskmovpd, _0, _1, _2)
-
+#define VMASKMOVPS(_0, _1, _2) INSTR_(vmaskmovps, _0, _1, _2)
 #define VFMADD132SS(_0, _1, _2) INSTR_(vfmadd132ss, _0, _1, _2)
 #define VFMADD213SS(_0, _1, _2) INSTR_(vfmadd213ss, _0, _1, _2)
 #define VFMADD231SS(_0, _1, _2) INSTR_(vfmadd231ss, _0, _1, _2)
@@ -1242,7 +1242,7 @@
 #define vblendpd(_0, _1, _2, _3) VBLENDPD(_0, _1, _2, _3)
 #define vblendmps(_0, _1, _2) VBLENDMSD(_0, _1, _2)
 #define vblendmpd(_0, _1, _2) VBLENDMPD(_0, _1, _2)
-
+#define vmaskmovps(_0, _1, _2) VMASKMOVPS(_0, _1, _2)
 #define vmaskmovpd(_0, _1, _2) VMASKMOVPD(_0, _1, _2)
 
 // Prefetches

--- a/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16.c
@@ -1,0 +1,2702 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020 - 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+/*
+   rrc:
+     --------        ------        | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------   +=   ------ ...    | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------        ------              :
+     --------        ------              :
+   Assumptions:
+   - C is row-stored and B is column-stored;
+   - A is row-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential microkernel is well-suited for
+   a dot-product-based accumulation that performs vector loads from
+   both A and B.
+*/
+void bli_sgemmsup_rd_zen_asm_2x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    // -------------------------------------------------------------------------
+    begin_asm()
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = unused
+    // r15 = n dim index jj
+    // r10 = unused
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), rcx)         // rcx = c + 4*jj*cs_c;
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rbx)         // rbx = b + 4*jj*cs_b;
+    lea(mem(r14), rax)                 // rax = a;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14    
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+    vhaddps(xmm2,xmm0,xmm5)               
+                                        // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vfmadd231ps(mem(rcx), xmm3,xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm5, mem(rcx))
+
+    label(.SDONE)
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(16), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm7", "ymm8",
+      "ymm10", "ymm11", "ymm13", "ymm14",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_1x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    // -------------------------------------------------------------------------
+    begin_asm()
+    mov(var(a), r14)                   // load address of a.
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    mov(var(c), r12)                   // load address of c
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm13, ymm13, ymm13)
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), rcx)         // rcx = c + 4*jj*cs_c;
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rbx)         // rbx = b + 4*jj*cs_b;
+    lea(mem(r14), rax)                 // rax = a;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13      
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+                                        // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)    
+    vmovups(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+
+    label(.SDONE)
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(16), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm2", "ymm3", "ymm4",
+      "ymm7", "ymm10", "ymm13",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_2x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    // -------------------------------------------------------------------------
+    begin_asm()
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = unused
+    // r15 = n dim index jj
+    // r10 = unused
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), rcx)         // rcx = c + 4*jj*cs_c;
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rbx)         // rbx = b + 4*jj*cs_b;
+    lea(mem(r14), rax)                 // rax = a;
+
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)    
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+    vhaddps(xmm2,xmm0,xmm5)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+                                           // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vfmadd231ps(mem(rcx), xmm3,xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    //add(rdi, rcx)
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm5, mem(rcx))
+
+    label(.SDONE)
+
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(8), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm7", "ymm8",
+      "ymm10", "ymm11", "ymm13", "ymm14",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_1x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    // -------------------------------------------------------------------------
+    begin_asm()
+    mov(var(a), r14)                   // load address of a.
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    mov(var(c), r12)                   // load address of c
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm13, ymm13, ymm13)
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), rcx)         // rcx = c + 4*jj*cs_c;
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rbx)         // rbx = b + 4*jj*cs_b;
+    lea(mem(r14), rax)                 // rax = a;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+        // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vfmadd231ps(mem(rcx), xmm3,xmm4)
+    vmovups(xmm4, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+
+    label(.SDONE)
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(4), r15)                   // compare jj to 4
+    jle(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm2", "ymm3", "ymm4",
+      "ymm7", "ymm10", "ymm13",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_2x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    // -------------------------------------------------------------------------
+    begin_asm()
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)    
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+    vhaddps(xmm2,xmm0,xmm5)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vfmadd231ps(mem(rcx), xmm3,xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm5, mem(rcx))
+    label(.SDONE)
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm7", "ymm8",
+      "ymm10", "ymm11", "ymm13", "ymm14",
+      "memory"
+    )
+}
+void bli_sgemmsup_rd_zen_asm_1x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()                        
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm13, ymm13, ymm13)
+    mov(var(a), rax)                   // load address of a.
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    mov(var(c), rcx)                   // load address of c
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+        mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rax       ), xmm0)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+    vhaddps(xmm2,xmm0,xmm4)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vfmadd231ps(mem(rcx), xmm3,xmm4)
+    vmovups(xmm4, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+    label(.SROWSTORBZ)
+    vmovups(xmm4, mem(rcx))
+
+    label(.SDONE)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm2", "ymm3", "ymm4",
+      "ymm7", "ymm10", "ymm13",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_2x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+                                       // initialize loop by pre-loading
+                                       // a column of a.
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    // ---------------------------------- iteration 2    
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rbx        ), xmm0)
+    vmovss(mem(rbx, r11, 1), xmm1)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vmovss(mem(rax        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rax, r8,  1), xmm3)
+    add(imm(1*4), rax)                 // a += 1*cs_a = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm5
+                                       // ymm6  ymm7
+    vhaddps( ymm5, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm4)
+    vhaddps( ymm7, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps(xmm0,xmm0,xmm6)                    // xmm4  = sum(ymm4)  sum(ymm5)
+                                       // xmm6  = sum(ymm6)  sum(ymm7)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4,  xmm4)          // scale by alpha
+    vmulps(xmm0, xmm6,  xmm6)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+        
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)    
+    label(.SROWSTORBZ)
+        
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)    
+    vmovsd(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm3", "ymm4",
+      "ymm5", "ymm6", "ymm7",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_1x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+
+    mov(var(a), rax)                   // load address of a.
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+                                       // initialize loop by pre-loading
+                                       // a column of a.
+    mov(var(c), rcx)                   // load address of c
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rbx        ), xmm0)
+    vmovss(mem(rbx, r11, 1), xmm1)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vmovss(mem(rax        ), xmm3)
+    add(imm(1*4), rax)                 // a += 1*cs_a = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm5
+    vhaddps( ymm5, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )          // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm4)             // xmm4  = sum(ymm4)  sum(ymm5)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4,  xmm4)          // scale by alpha
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovsd(xmm4, mem(rcx))
+
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm3", "ymm4",
+      "ymm5",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rd_zen_asm_6x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    if ( m_iter == 0 ) goto consider_edge_cases;
+    // -------------------------------------------------------------------------
+    begin_asm()
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    // r12 = rcx = c
+        // r14 = rax = a
+        // rdx = rbx = b
+        // r9  = m dim index ii
+    mov(var(m_iter), r9)               // ii = m_iter;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle,
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c + 6*ii*rs_c;
+        lea(mem(r14), rax)                 // rax = a + 6*ii*rs_a;
+        lea(mem(rdx), rbx)                 // rbx = b;
+
+    lea(mem(rcx, rdi, 2), r10)         //
+    lea(mem(r10, rdi, 1), r10)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 1*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(r10, 1*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(r10, rdi, 1, 1*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(r10, rdi, 2, 1*8)) // prefetch c + 5*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovups(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rax, r8,  4), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovups(mem(rax, r15, 1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovups(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rax, r8,  4), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovups(mem(rax, r15, 1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovups(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rax, r8,  4), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovups(mem(rax, r15, 1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovups(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rax, r8,  4), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovups(mem(rax, r15, 1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovups(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovups(mem(rax, r8,  4), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovups(mem(rax, r15, 1), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rbx        ), xmm0)
+    vmovss(mem(rbx, r11, 1), xmm1)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vmovss(mem(rax        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovss(mem(rax, r8,  2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    vmovss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vmovss(mem(rax, r8,  4), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm12)
+    vfmadd231ps(ymm1, ymm3, ymm13)
+    vmovss(mem(rax, r15, 1), xmm3)
+    add(imm(1*4), rax)                 // a += 1*cs_a = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm5
+                                       // ymm6  ymm7
+                                       // ymm8  ymm9
+                                       // ymm10 ymm11
+                                       // ymm12 ymm13
+                                       // ymm14 ymm15
+    vhaddps( ymm5, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm4)
+    vhaddps( ymm7, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm6)
+    vhaddps( ymm9, ymm8, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm8)
+    vhaddps( ymm11, ymm10, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm10)
+    vhaddps( ymm13, ymm12, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm12)
+    vhaddps( ymm15, ymm14, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm14)
+                                       // xmm4  = sum(ymm4)  sum(ymm5)
+                                       // xmm6  = sum(ymm6)  sum(ymm7)
+                                       // xmm8  = sum(ymm8)  sum(ymm9)
+                                       // xmm10 = sum(ymm10) sum(ymm11)
+                                       // xmm12 = sum(ymm12) sum(ymm13)
+                                       // xmm14 = sum(ymm14) sum(ymm15)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4,  xmm4)          // scale by alpha
+    vmulps(xmm0, xmm6,  xmm6)
+    vmulps(xmm0, xmm8,  xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm6)//c*beta+(a0a1)
+    vmovsd(xmm6, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm8)//c*beta+(a0a1)
+    vmovsd(xmm8, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm10)//c*beta+(a0a1)
+    vmovsd(xmm10, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm12)//c*beta+(a0a1)
+    vmovsd(xmm12, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm14)//c*beta+(a0a1)
+    vmovsd(xmm14, mem(rcx))//a0a1
+    //add(rdi, rcx)
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm10, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm14, mem(rcx))
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+        lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+        lea(mem(r14, r8,  4), r14)         //
+        lea(mem(r14, r8,  2), r14)         // a_ii = r14 += 6*rs_a
+        dec(r9)                            // ii -= 1;
+        jne(.SLOOP3X4I)                    // iterate again if ii != 0.
+
+
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm3", "ymm4",
+      "ymm5", "ymm6", "ymm7", "ymm8",
+      "ymm9", "ymm10", "ymm11", "ymm12",
+      "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+    consider_edge_cases:
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 2;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a + i_edge*rs_a;
+        if ( 3 <= m_left )
+        {
+            const dim_t mr_cur = 3;
+            bli_sgemmsup_rd_zen_asm_3x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 2 <= m_left )
+        {
+            const dim_t mr_cur = 2;
+            bli_sgemmsup_rd_zen_asm_2x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            const dim_t mr_cur = 1;
+            bli_sgemmsup_rd_zen_asm_1x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_3x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+                                       // initialize loop by pre-loading
+                                       // a column of a.
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+        // ---------------------------------- iteration 0
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+
+    // ---------------------------------- iteration 2    
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+    vmovups(mem(rbx        ), ymm0)
+    vmovups(mem(rbx, r11, 1), ymm1)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vmovups(mem(rax        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovups(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovups(mem(rax, r8,  2), ymm3)
+    add(imm(8*4), rax)                 // a += 4*cs_a = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+    vmovss(mem(rbx        ), xmm0)
+    vmovss(mem(rbx, r11, 1), xmm1)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vmovss(mem(rax        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vmovss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    vmovss(mem(rax, r8,  2), xmm3)
+    add(imm(1*4), rax)                 // a += 1*cs_a = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm8)
+    vfmadd231ps(ymm1, ymm3, ymm9)
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm5
+                                       // ymm6  ymm7
+                                       // ymm8  ymm9
+    vhaddps( ymm5, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm5)
+    vhaddps(xmm0,xmm0,xmm4)
+    vhaddps( ymm7, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps(xmm0,xmm0,xmm6)
+    vhaddps( ymm9, ymm8, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps(xmm0,xmm0,xmm8)            // xmm4  = sum(ymm4)  sum(ymm5)
+                                       // xmm6  = sum(ymm6)  sum(ymm7)
+                                       // xmm8  = sum(ymm8)  sum(ymm9)
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    vmulps(xmm0, xmm4,  xmm4)          // scale by alpha
+    vmulps(xmm0, xmm6,  xmm6)
+    vmulps(xmm0, xmm8,  xmm8)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovsd(xmm8, mem(rcx))
+    //add(rdi, rcx)    
+    
+    jmp(.SDONE)                        // jump to end.
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm8, mem(rcx))
+
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm3", "ymm4",
+      "ymm5", "ymm6", "ymm7", "ymm8",
+      "ymm9",
+      "memory"
+    )
+}

--- a/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16m.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16m.c
@@ -1,0 +1,1981 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020 - 2023, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+/*
+   rrc:
+     --------        ------        | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------   +=   ------ ...    | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------        ------              :
+     --------        ------              :
+
+   Assumptions:
+   - C is row-stored and B is column-stored;
+   - A is row-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential microkernel is well-suited for
+   a dot-product-based accumulation that performs vector loads from
+   both A and B.
+
+   NOTE: These kernels implicitly support column-oriented IO, implemented
+   via an a high-level transposition of the entire operation. A and B will
+   effectively remain row- and column-stored, respectively, but C will then
+   effectively appear column-stored. Thus, this kernel may be used for both
+   rrc and crc cases.
+*/
+
+// Prototype reference microkernels.
+
+void bli_sgemmsup_rd_zen_asm_6x16m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+
+    uint64_t n_left = n0 % 16;
+
+    // First check whether this is a edge case in the n dimension. If so,
+    // dispatch other 6x?m kernels, as needed.
+    if ( n_left )
+    {
+        float* restrict cij = (float *)c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a;
+
+        if ( 8 <= n_left )
+        {
+            const dim_t nr_cur = 8;
+
+            bli_sgemmsup_rd_zen_asm_6x8m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 4 <= n_left )
+        {
+            const dim_t nr_cur = 4;
+
+            bli_sgemmsup_rd_zen_asm_6x4m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_6x2m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 1 == n_left )
+        {
+            bli_sgemv_ex
+            (
+              BLIS_NO_TRANSPOSE, conjb, m0, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+              beta, cij, rs_c0, cntx, NULL
+            );
+        }
+        return;
+    }
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t m_iter = m0 / 3;
+    uint64_t m_left = m0 % 3;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    lea(mem(r8,  r8,  2), r10)         // r10 = 3*rs_a
+
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+
+
+
+    mov(var(a), r14)                   // load address of a
+    mov(var(c), r12)                   // load address of c
+    mov(var(b), rdx)
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), r12)         // r12 = c + 4*jj*cs_c;
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rdx)         // rbx = b + 4*jj*cs_b;
+
+
+
+    mov(var(m_iter), r9)               // ii = m_iter;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(r14), rax)                 // rax = a_ii;
+    lea(mem(rdx), rbx)                 // rbx = b_jj;
+
+    lea(mem(r8,  r8,  4), rdi)         // rdi = 5*rs_a
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*4;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*4;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15 
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm15, ymm12, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm6)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+                                       // ymm6 = sum(ymm6) sum(ymm9) sum(ymm12) sum(ymm15)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                           // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 2), r12)         //
+    lea(mem(r12, rdi, 1), r12)         // c_ii = r12 += 3*rs_c
+
+    lea(mem(r14, r8,  2), r14)         //
+    lea(mem(r14, r8,  1), r14)         // a_ii = r14 += 3*rs_a
+
+    dec(r9)                            // ii -= 1;
+    jne(.SLOOP3X4I)                    // iterate again if ii != 0.
+
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(16), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 16;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a + i_edge*rs_a;
+
+        if ( 2 == m_left )
+        {
+            const dim_t mr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x16
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            //cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            const dim_t mr_cur = 1;
+
+            bli_sgemmsup_rd_zen_asm_1x16
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_6x8m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t m_iter = m0 / 3;
+    uint64_t m_left = m0 % 3;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    lea(mem(r8,  r8,  2), r10)         // r10 = 3*rs_a
+
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+
+
+
+    mov(var(a), r14)                   // load address of a
+    mov(var(c), r12)                   // load address of c
+    mov(var(b), rdx)
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), r12)         // r12 = c + 4*jj*cs_c;
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rdx)         // rbx = b + 4*jj*cs_b;
+
+
+
+    mov(var(m_iter), r9)               // ii = m_iter;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(r14), rax)                 // rax = a_ii;
+    lea(mem(rdx), rbx)                 // rbx = b_jj;
+
+    lea(mem(r8,  r8,  4), rdi)         // rdi = 5*rs_a
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    // ---------------------------------- iteration 1
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    // ---------------------------------- iteration 3
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*4;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*4;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15 
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm15, ymm12, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm6)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+                                       // ymm6 = sum(ymm6) sum(ymm9) sum(ymm12) sum(ymm15)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                           // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 2), r12)         //
+    lea(mem(r12, rdi, 1), r12)         // c_ii = r12 += 3*rs_c
+
+    lea(mem(r14, r8,  2), r14)         //
+    lea(mem(r14, r8,  1), r14)         // a_ii = r14 += 3*rs_a
+
+    dec(r9)                            // ii -= 1;
+    jne(.SLOOP3X4I)                    // iterate again if ii != 0.
+
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(8), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 8;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a + i_edge*rs_a;
+
+        if ( 2 == m_left )
+        {
+            const dim_t mr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x8
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            //cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            const dim_t mr_cur = 1;
+
+            bli_sgemmsup_rd_zen_asm_1x8
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+        }
+    }
+}
+
+
+
+void bli_sgemmsup_rd_zen_asm_6x4m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t m_iter = m0 / 3;
+    uint64_t m_left = m0 % 3;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    lea(mem(r8,  r8,  2), r10)         // r10 = 3*rs_a
+
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+
+
+
+    mov(var(a), r14)                   // load address of a
+    mov(var(c), r12)                   // load address of c
+    mov(var(b), rdx)
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), r12)         // r12 = c + 4*jj*cs_c;
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rdx)         // rbx = b + 4*jj*cs_b;
+
+
+
+    mov(var(m_iter), r9)               // ii = m_iter;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(r14), rax)                 // rax = a_ii;
+    lea(mem(rdx), rbx)                 // rbx = b_jj;
+
+    lea(mem(r8,  r8,  4), rdi)         // rdi = 5*rs_a
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*4;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*4;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15 
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps( ymm15, ymm12, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm6)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+                                       // ymm6 = sum(ymm6) sum(ymm9) sum(ymm12) sum(ymm15)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                           // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 2), r12)         //
+    lea(mem(r12, rdi, 1), r12)         // c_ii = r12 += 3*rs_c
+
+    lea(mem(r14, r8,  2), r14)         //
+    lea(mem(r14, r8,  1), r14)         // a_ii = r14 += 3*rs_a
+
+    dec(r9)                            // ii -= 1;
+    jne(.SLOOP3X4I)                    // iterate again if ii != 0.
+
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(4), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 4;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a + i_edge*rs_a;
+
+        if ( 2 == m_left )
+        {
+            const dim_t mr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x4
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            //cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            const dim_t mr_cur = 1;
+
+            bli_sgemmsup_rd_zen_asm_1x4
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_6x2m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t m_iter = m0 / 3;
+    uint64_t m_left = m0 % 3;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+ 
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), rdx)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+    lea(mem(r8,  r8,  2), r10)         // r10 = 3*rs_a
+
+    // r12 = rcx = c
+    // r14 = rax = a
+    // rdx = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+
+    mov(imm(0), r15)                   // jj = 0;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ 0 1 ... ]
+
+
+
+    mov(var(a), r14)                   // load address of a
+    mov(var(c), r12)                   // load address of c
+    mov(var(b), rdx)
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(imm(1*4), rsi)                // rsi *= cs_c = 1*8
+    lea(mem(r12, rsi, 1), r12)         // r12 = c + 4*jj*cs_c;
+
+    lea(mem(   , r15, 1), rsi)         // rsi = r15 = 4*jj;
+    imul(r11, rsi)                     // rsi *= cs_b;
+    lea(mem(rdx, rsi, 1), rdx)         // rbx = b + 4*jj*cs_b;
+
+
+
+    mov(var(m_iter), r9)               // ii = m_iter;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(r14), rax)                 // rax = a_ii;
+    lea(mem(rdx), rbx)                 // rbx = b_jj;
+
+    lea(mem(r8,  r8,  4), rdi)         // rdi = 5*rs_a
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    // ---------------------------------- iteration 3
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    prefetch(0, mem(rax, r10, 1, 0*8)) // prefetch rax + 3*cs_a
+    prefetch(0, mem(rax, r8,  4, 0*8)) // prefetch rax + 4*cs_a
+    prefetch(0, mem(rax, rdi, 1, 0*8)) // prefetch rax + 5*cs_a
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*4;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*4;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  
+                                       // ymm5  ymm8 
+                                       // ymm6  ymm9 
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+    vhaddps(xmm0,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps(xmm0,xmm0,xmm5)
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+    vhaddps(xmm0,xmm0,xmm6)
+                                       // ymm4 = sum(ymm4) sum(ymm7)
+                                       // ymm5 = sum(ymm5) sum(ymm8)
+                                       // ymm6 = sum(ymm6) sum(ymm9)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                           // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm5)
+    vmovsd(xmm5, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+    label(.SROWSTORBZ)
+
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm5, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 2), r12)         //
+    lea(mem(r12, rdi, 1), r12)         // c_ii = r12 += 3*rs_c
+
+    lea(mem(r14, r8,  2), r14)         //
+    lea(mem(r14, r8,  1), r14)         // a_ii = r14 += 3*rs_a
+
+    dec(r9)                            // ii -= 1;
+    jne(.SLOOP3X4I)                    // iterate again if ii != 0.
+
+    add(imm(4), r15)                   // jj += 4;
+    cmp(imm(4), r15)                   // compare jj to 4
+    jl(.SLOOP3X4J)                    // if jj <= 4, jump to beginning
+                                       // of jj loop; otherwise, loop ends.
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 2;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a + i_edge*rs_a;
+
+        if ( 2 == m_left )
+        {
+            const dim_t mr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            //cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            const dim_t mr_cur = 1;
+
+            bli_sgemmsup_rd_zen_asm_1x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+        }
+    }
+}
+

--- a/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16n.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rd_zen_asm_s6x16n.c
@@ -1,0 +1,1883 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020 - 2023, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+/*
+   rrc:
+     --------        ------        | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------   +=   ------ ...    | | | | | | | |
+     --------        ------        | | | | | | | |
+     --------        ------              :
+     --------        ------              :
+
+   Assumptions:
+   - C is row-stored and B is column-stored;
+   - A is row-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential microkernel is well-suited for
+   a dot-product-based accumulation that performs vector loads from
+   both A and B.
+
+   NOTE: These kernels implicitly support column-oriented IO, implemented
+   via an a high-level transposition of the entire operation. A and B will
+   effectively remain row- and column-stored, respectively, but C will then
+   effectively appear column-stored. Thus, this kernel may be used for both
+   rrc and crc cases.
+*/
+
+void bli_sgemmsup_rd_zen_asm_6x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    uint64_t m_left = m0 % 6;
+
+    // First check whether this is a edge case in the n dimension. If so,
+    // dispatch other ?x8m kernels, as needed.
+    if ( m_left )
+    {
+        float* restrict cij = (float *)c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a;
+
+        // We add special handling for slightly inflated MR blocksizes
+        // at edge cases, up to a maximum of 9.
+        if ( 6 < m0 )
+        {
+            gemmsup_ker_ft ker_fp1 = NULL;
+            gemmsup_ker_ft ker_fp2 = NULL;
+            dim_t           mr1, mr2;
+
+            if ( m0 == 7 )
+            {
+                mr1 = 6; mr2 = 1;
+                ker_fp1 = bli_sgemmsup_rd_zen_asm_6x16n;
+                ker_fp2 = bli_sgemmsup_rd_zen_asm_1x16n;
+            }
+            else if ( m0 == 8 )
+            {
+                mr1 = 6; mr2 = 2;
+                ker_fp1 = bli_sgemmsup_rd_zen_asm_6x16n;
+                ker_fp2 = bli_sgemmsup_rd_zen_asm_2x16n;
+            }
+            else // if ( m0 == 9 )
+            {
+                mr1 = 6; mr2 = 3;
+                ker_fp1 = bli_sgemmsup_rd_zen_asm_6x16n;
+                ker_fp2 = bli_sgemmsup_rd_zen_asm_3x16n;
+            }
+
+            ker_fp1
+            (
+              conja, conjb, mr1, n0, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += mr1*rs_c0; ai += mr1*rs_a0;
+
+            ker_fp2
+            (
+              conja, conjb, mr2, n0, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+
+            return;
+        }
+
+        if ( 3 <= m_left )
+        {
+            const dim_t mr_cur = 3;
+
+            bli_sgemmsup_rd_zen_asm_3x16n
+            (
+              conja, conjb, mr_cur, n0, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 2 <= m_left )
+        {
+            const dim_t mr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x16n
+            (
+              conja, conjb, mr_cur, n0, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += mr_cur*rs_c0; ai += mr_cur*rs_a0; m_left -= mr_cur;
+        }
+        if ( 1 == m_left )
+        {
+            bli_sgemv_ex
+            (
+              BLIS_TRANSPOSE, conja, k0, n0,
+              alpha, bj, rs_b0, cs_b0, ai, cs_a0,
+              beta, cij, cs_c0, cntx, NULL
+            );
+        }
+        return;
+    }
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t n_iter = n0 / 4;
+    uint64_t n_left = n0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( n_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), rdx)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+
+    // r12 = rcx = c
+    // rdx = rax = a
+    // r14 = rbx = b
+    // r9  = m dim index ii
+    // r15 = n dim index jj
+
+    mov(imm(0), r9)                    // ii = 0;
+
+    label(.SLOOP3X4I)                  // LOOP OVER ii = [ 0 1 ... ]
+
+    mov(var(b), r14)                   // load address of b
+    mov(var(c), r12)                   // load address of c
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    lea(mem(   , r9,  1), rsi)         // rsi = r9 = 3*ii;
+    imul(rdi, rsi)                     // rsi *= rs_c
+    lea(mem(r12, rsi, 1), r12)         // r12 = c + 3*ii*rs_c;
+
+    lea(mem(   , r9,  1), rsi)         // rsi = r9 = 3*ii;
+    imul(r8,  rsi)                     // rsi *= rs_a;
+    lea(mem(rdx, rsi, 1), rdx)         // rax = a + 3*ii*rs_a;
+
+    mov(var(n_iter), r15)              // jj = n_iter;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(rdx), rax)                 // rax = a_ii;
+    lea(mem(r14), rbx)                 // rbx = b_jj;
+
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+
+    lea(mem(r11, r11, 2), rdi)         // rdi = 3*cs_b
+    lea(mem(rbx, r11, 4), r10)         // r10 = rbx + 4*cs_b
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(r10,         0*8)) // prefetch rbx + 4*cs_b
+    prefetch(0, mem(r10, r11, 1, 0*8)) // prefetch rbx + 5*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(r10, r11, 2, 0*8)) // prefetch rbx + 6*cs_b
+    prefetch(0, mem(r10, r13, 1, 0*8)) // prefetch rbx + 7*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(r10,         8*8)) // prefetch rbx + 4*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r11, 1, 8*8)) // prefetch rbx + 5*cs_b + 8*rs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(r10, r11, 2, 8*8)) // prefetch rbx + 6*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r13, 1, 8*8)) // prefetch rbx + 7*cs_b + 8*rs_b
+    add(imm(16*8), r10)                 // r10 += 8*rs_b = 8*8;
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+
+    vhaddps( ymm15, ymm12, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm6)
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+                                       // ymm6 = sum(ymm6) sum(ymm9) sum(ymm12) sum(ymm15)
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    add(imm(4*4), r12)                 // c_jj = r12 += 4*cs_c
+
+    lea(mem(r14, r11, 4), r14)         // b_jj = r14 += 4*cs_b
+
+    dec(r15)                           // jj -= 1;
+    jne(.SLOOP3X4J)                    // iterate again if jj != 0.
+
+    add(imm(3), r9)                    // ii += 3;
+    cmp(imm(3), r9)                    // compare ii to 3
+    jle(.SLOOP3X4I)                    // if ii <= 3, jump to beginning
+                                       // of ii loop; otherwise, loop ends.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( n_left )
+    {
+        const dim_t      mr_cur = 6;
+        const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+        float* restrict cij = (float *)c + j_edge*cs_c;
+        float* restrict ai  = (float *)a;
+        float* restrict bj  = (float *)b + j_edge*cs_b;
+
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_6x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 1 == n_left )
+        {
+            bli_sgemv_ex
+            (
+              BLIS_NO_TRANSPOSE, conjb, mr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+              beta, cij, rs_c0, cntx, NULL
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_3x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t n_iter = n0 / 4;
+    uint64_t n_left = n0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( n_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), rdx)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    mov(var(b), r14)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+
+    mov(var(c), r12)                   // load address of c
+
+    // r12 = rcx = c
+    // rdx = rax = a
+    // r14 = rbx = b
+    // r9  = unused
+    // r15 = n dim index jj
+
+    mov(var(n_iter), r15)              // jj = n_iter;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(rdx), rax)                 // rax = a_ii;
+    lea(mem(r14), rbx)                 // rbx = b_jj;
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+
+    lea(mem(r11, r11, 2), rdi)         // rdi = 3*cs_b
+    lea(mem(rbx, r11, 4), r10)         // r10 = rbx + 4*cs_b
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(r10,         0*8)) // prefetch rbx + 4*cs_b
+    prefetch(0, mem(r10, r11, 1, 0*8)) // prefetch rbx + 5*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(r10, r11, 2, 0*8)) // prefetch rbx + 6*cs_b
+    prefetch(0, mem(r10, r13, 1, 0*8)) // prefetch rbx + 7*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(r10,         8*8)) // prefetch rbx + 4*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r11, 1, 8*8)) // prefetch rbx + 5*cs_b + 8*rs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(r10, r11, 2, 8*8)) // prefetch rbx + 6*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r13, 1, 8*8)) // prefetch rbx + 7*cs_b + 8*rs_b
+    add(imm(16*8), r10)                 // r10 += 8*rs_b = 8*8;
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    vmovups(mem(rax, r8, 2), ymm2)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    vmovss(mem(rax, r8, 2), xmm2)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+    vfmadd231ps(ymm2, ymm3, ymm6)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+    vfmadd231ps(ymm2, ymm3, ymm9)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    vfmadd231ps(ymm2, ymm3, ymm12)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+    vfmadd231ps(ymm2, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15
+
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+
+    vhaddps( ymm9, ymm6, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+
+    vhaddps( ymm15, ymm12, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm6)
+
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+                                       // ymm6 = sum(ymm6) sum(ymm9) sum(ymm12) sum(ymm15)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+
+    label(.SDONE)
+
+    add(imm(4*4), r12)                 // c_jj = r12 += 4*cs_c
+
+    lea(mem(r14, r11, 4), r14)         // b_jj = r14 += 4*cs_b
+
+    dec(r15)                           // jj -= 1;
+    jne(.SLOOP3X4J)                    // iterate again if jj != 0.
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( n_left )
+    {
+        const dim_t      mr_cur = 3;
+        const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+        float* restrict cij = (float *)c + j_edge*cs_c;
+        float* restrict ai  = (float *)a;
+        float* restrict bj  = (float *)b + j_edge*cs_b;
+
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_3x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 1 == n_left )
+        {
+            bli_sgemv_ex
+            (
+              BLIS_NO_TRANSPOSE, conjb, mr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+              beta, cij, rs_c0, cntx, NULL
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_2x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t n_iter = n0 / 4;
+    uint64_t n_left = n0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( n_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), rdx)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    mov(var(b), r14)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+
+    mov(var(c), r12)                   // load address of c
+
+    // r12 = rcx = c
+    // rdx = rax = a
+    // r14 = rbx = b
+    // r9  = unused
+    // r15 = n dim index jj
+
+    mov(var(n_iter), r15)              // jj = n_iter;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(rdx), rax)                 // rax = a_ii;
+    lea(mem(r14), rbx)                 // rbx = b_jj;
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+
+    lea(mem(r11, r11, 2), rdi)         // rdi = 3*cs_b
+    lea(mem(rbx, r11, 4), r10)         // r10 = rbx + 4*cs_b
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(r10,         0*8)) // prefetch rbx + 4*cs_b
+    prefetch(0, mem(r10, r11, 1, 0*8)) // prefetch rbx + 5*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(r10, r11, 2, 0*8)) // prefetch rbx + 6*cs_b
+    prefetch(0, mem(r10, r13, 1, 0*8)) // prefetch rbx + 7*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(r10,         8*8)) // prefetch rbx + 4*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r11, 1, 8*8)) // prefetch rbx + 5*cs_b + 8*rs_b
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(r10, r11, 2, 8*8)) // prefetch rbx + 6*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r13, 1, 8*8)) // prefetch rbx + 7*cs_b + 8*rs_b
+    add(imm(16*8), r10)                 // r10 += 8*rs_b = 8*8;
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    vmovups(mem(rax       ), ymm0)
+    vmovups(mem(rax, r8, 1), ymm1)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    vmovss(mem(rax, r8, 1), xmm1)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+    vfmadd231ps(ymm1, ymm3, ymm5)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+    vfmadd231ps(ymm1, ymm3, ymm8)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+    vfmadd231ps(ymm1, ymm3, ymm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15
+
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+    vhaddps( ymm8, ymm5, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )
+
+    vhaddps( ymm14, ymm11, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )
+
+    vhaddps(xmm2,xmm0,xmm5)
+
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+                                       // ymm5 = sum(ymm5) sum(ymm8) sum(ymm11) sum(ymm14)
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm5, xmm5)
+    vmulps(xmm0, xmm6, xmm6)
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm5)
+    vmovups(xmm5, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm5, mem(rcx))
+
+    label(.SDONE)
+
+    add(imm(4*4), r12)                 // c_jj = r12 += 4*cs_c
+
+    lea(mem(r14, r11, 4), r14)         // b_jj = r14 += 4*cs_b
+
+    dec(r15)                           // jj -= 1;
+    jne(.SLOOP3X4J)                    // iterate again if jj != 0.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm7", "ymm8",
+      "ymm10", "ymm11", "ymm13", "ymm14",
+      "ymm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( n_left )
+    {
+        const dim_t      mr_cur = 2;
+        const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+        float* restrict cij = (float *)c + j_edge*cs_c;
+        float* restrict ai  = (float *)a;
+        float* restrict bj  = (float *)b + j_edge*cs_b;
+
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_2x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 1 == n_left )
+        {
+            bli_sgemv_ex
+            (
+              BLIS_NO_TRANSPOSE, conjb, mr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+              beta, cij, rs_c0, cntx, NULL
+            );
+        }
+    }
+}
+
+void bli_sgemmsup_rd_zen_asm_1x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter32 = k0 / 32;
+    uint64_t k_left32 = k0 % 32;
+    uint64_t k_iter8  = k_left32 / 8;
+    uint64_t k_left1  = k_left32 % 8;
+
+    uint64_t n_iter = n0 / 4;
+    uint64_t n_left = n0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    if ( n_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), rdx)                   // load address of a.
+
+    mov(var(b), r14)                   // load address of b.
+    mov(var(cs_b), r11)                // load cs_b
+    lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+    lea(mem(r11, r11, 2), r13)         // r13 = 3*cs_b
+
+    mov(var(c), r12)                   // load address of c
+
+    // r12 = rcx = c
+    // rdx = rax = a
+    // r14 = rbx = b
+    // r9  = unused
+    // r15 = n dim index jj
+
+    mov(var(n_iter), r15)              // jj = n_iter;
+
+    label(.SLOOP3X4J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+                                       // zen2 can execute 4 vxorpd ipc with
+                                       // a latency of 1 cycle
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm13, ymm13, ymm13)
+
+    lea(mem(r12), rcx)                 // rcx = c_iijj;
+    lea(mem(rdx), rax)                 // rax = a_ii;
+    lea(mem(r14), rbx)                 // rbx = b_jj;
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+
+    lea(mem(r11, r11, 2), rdi)         // rdi = 3*cs_b
+    lea(mem(rbx, r11, 4), r10)         // r10 = rbx + 4*cs_b
+
+
+    mov(var(k_iter32), rsi)            // i = k_iter32;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKITER8)                 // if i == 0, jump to code that
+                                       // contains the k_iter8 loop.
+
+    label(.SLOOPKITER32)               // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(r10,         0*8)) // prefetch rbx + 4*cs_b
+    prefetch(0, mem(r10, r11, 1, 0*8)) // prefetch rbx + 5*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(r10, r11, 2, 0*8)) // prefetch rbx + 6*cs_b
+    prefetch(0, mem(r10, r13, 1, 0*8)) // prefetch rbx + 7*cs_b
+
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(r10,         8*8)) // prefetch rbx + 4*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r11, 1, 8*8)) // prefetch rbx + 5*cs_b + 8*rs_b
+
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(r10, r11, 2, 8*8)) // prefetch rbx + 6*cs_b + 8*rs_b
+    prefetch(0, mem(r10, r13, 1, 8*8)) // prefetch rbx + 7*cs_b + 8*rs_b
+    add(imm(16*8), r10)                 // r10 += 8*rs_b = 8*8;
+
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER32)                 // iterate again if i != 0.
+
+    label(.SCONSIDKITER8)
+
+    mov(var(k_iter8), rsi)             // i = k_iter8;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT1)                 // if i == 0, jump to code that
+                                       // considers k_left1 loop.
+                                       // else, we prepare to enter k_iter8 loop.
+
+    label(.SLOOPKITER8)                // EDGE LOOP (ymm)
+
+    vmovups(mem(rax       ), ymm0)
+    add(imm(8*4), rax)                 // a += 4*cs_b = 4*8;
+
+    vmovups(mem(rbx        ), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovups(mem(rbx, r11, 1), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovups(mem(rbx, r11, 2), ymm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovups(mem(rbx, r13, 1), ymm3)
+    add(imm(8*4), rbx)                 // b += 4*rs_b = 4*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER8)                  // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT1)
+
+    mov(var(k_left1), rsi)             // i = k_left1;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left1 loop.
+
+    label(.SLOOPKLEFT1)                // EDGE LOOP (scalar)
+                                       // NOTE: We must use ymm registers here bc
+                                       // using the xmm registers would zero out the
+                                       // high bits of the destination registers,
+                                       // which would destory intermediate results.
+
+    vmovss(mem(rax       ), xmm0)
+    add(imm(1*4), rax)                 // a += 1*cs_b = 1*8;
+
+    vmovss(mem(rbx        ), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm4)
+
+    vmovss(mem(rbx, r11, 1), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm7)
+
+    vmovss(mem(rbx, r11, 2), xmm3)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vmovss(mem(rbx, r13, 1), xmm3)
+    add(imm(1*4), rbx)                 // b += 1*rs_b = 1*8;
+    vfmadd231ps(ymm0, ymm3, ymm13)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT1)                  // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+                                       // ymm4  ymm7  ymm10 ymm13  
+                                       // ymm5  ymm8  ymm11 ymm14
+                                       // ymm6  ymm9  ymm12 ymm15
+
+    vhaddps( ymm7, ymm4, ymm0 )
+    vextractf128(imm(1), ymm0, xmm1 )
+    vaddps( xmm0, xmm1, xmm0 )         // xmm0[0] = sum(ymm4); xmm0[1] = sum(ymm7)
+
+    vhaddps( ymm13, ymm10, ymm2 )
+    vextractf128(imm(1), ymm2, xmm1 )
+    vaddps( xmm2, xmm1, xmm2 )         // xmm2[0] = sum(ymm10); xmm2[1] = sum(ymm13)
+
+    vhaddps(xmm2,xmm0,xmm4)
+
+                                       // ymm4 = sum(ymm4) sum(ymm7) sum(ymm10) sum(ymm13)
+
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomisd(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+
+    label(.SDONE)
+
+    add(imm(4*4), r12)                 // c_jj = r12 += 4*cs_c
+
+    lea(mem(r14, r11, 4), r14)         // b_jj = r14 += 4*cs_b
+
+    dec(r15)                           // jj -= 1;
+    jne(.SLOOP3X4J)                    // iterate again if jj != 0.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter32] "m" (k_iter32),
+      [k_iter8] "m" (k_iter8),
+      [k_left1] "m" (k_left1),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm2", "ymm3", "ymm4",
+      "ymm7", "ymm10", "ymm13",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( n_left )
+    {
+        const dim_t      mr_cur = 1;
+        const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+        float* restrict cij = (float *)c + j_edge*cs_c;
+        float* restrict ai  = (float *)a;
+        float* restrict bj  = (float *)b + j_edge*cs_b;
+
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rd_zen_asm_1x2
+            (
+              conja, conjb, mr_cur, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+        if ( 1 == n_left )
+        {
+            bli_sdotxv_ex
+            (
+              conja, conjb, k0,
+              alpha, ai, cs_a0, bj, rs_b0,
+              beta, cij, cntx, NULL
+            );
+        }
+    }
+}
+

--- a/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16.c
@@ -1,0 +1,8735 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020 - 2023, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+/*
+   rrr:
+    --------        ------        --------      
+    --------        ------        --------      
+    --------   +=   ------ ...    --------      
+    --------        ------        --------      
+    --------        ------            :         
+    --------        ------            :         
+
+   rcr:
+    --------        | | | |       --------      
+    --------        | | | |       --------      
+    --------   +=   | | | | ...   --------      
+    --------        | | | |       --------      
+    --------        | | | |           :         
+    --------        | | | |           :         
+
+   Assumptions:
+   - B is row-stored;
+   - A is row- or column-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential kernel is well-suited for contiguous
+   (v)ector loads on B and single-element broadcasts from A.
+
+   NOTE: These kernels explicitly support column-oriented IO, implemented
+   via an in-register transpose. And thus they also support the crr and
+   ccr cases, though only crr is ever utilized (because ccr is handled by
+   transposing the operation and executing rcr, which does not incur the
+   cost of the in-register transpose).
+
+   crr:
+    | | | | | | | |       ------        --------      
+    | | | | | | | |       ------        --------      
+    | | | | | | | |  +=   ------ ...    --------      
+    | | | | | | | |       ------        --------      
+    | | | | | | | |       ------            :         
+    | | | | | | | |       ------            :         
+*/
+// Prototype reference microkernels.
+GEMMSUP_KER_PROT( float,   s, gemmsup_r_zen_ref )
+
+void bli_sgemmsup_rv_zen_asm_5x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+	vmovaps(ymm4, ymm5)
+	vmovaps(ymm4, ymm6)
+	vmovaps(ymm4, ymm7)
+	vmovaps(ymm4, ymm8)
+	vmovaps(ymm4, ymm9)
+	vmovaps(ymm4, ymm10)
+	vmovaps(ymm4, ymm11)
+	vmovaps(ymm4, ymm12)
+	vmovaps(ymm4, ymm13)
+	vmovaps(ymm4, ymm14)
+	vmovaps(ymm4, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 7*8)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 4*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 4*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 4*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 4*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 4*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 4*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 4*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 4*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+        
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm13, ymm13)
+    
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm7)
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+        
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm9)
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+        
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm11)
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm12)
+    vmovups(ymm12, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm13)
+    vmovups(ymm13, mem(rcx, rsi, 8))
+    //add(rdi, rcx)    
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    
+    /*********************************************/
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+        
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    //lea(mem(rcx, rsi, 8), rcx) // rcx += 8*cs_c
+    vextractf128(imm(0x0), ymm13, xmm0)//e0-e3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0,xmm0, xmm1)
+    vshufps(imm(0x02), xmm0,xmm0, xmm2)
+    vshufps(imm(0x03), xmm0,xmm0, xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm13, xmm0)//e4-e7
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0,xmm0, xmm1)
+    vshufps(imm(0x02), xmm0,xmm0, xmm2)
+    vshufps(imm(0x03), xmm0,xmm0, xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+    
+    vmovups(ymm8, mem(rcx))
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+    
+    vmovups(ymm10, mem(rcx))
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+    
+    vmovups(ymm12, mem(rcx))
+    vmovups(ymm13, mem(rcx, rsi, 8))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    
+    /*********************************************/
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+        
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    vextractf128(imm(0x0), ymm13, xmm0)//e0-e3
+    vshufps(imm(0x01), xmm0,xmm0, xmm1)
+    vshufps(imm(0x02), xmm0,xmm0, xmm2)
+    vshufps(imm(0x03), xmm0,xmm0, xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm13, xmm0)//e4-e7
+    vshufps(imm(0x01), xmm0,xmm0, xmm1)
+    vshufps(imm(0x02), xmm0,xmm0, xmm2)
+    vshufps(imm(0x03), xmm0,xmm0, xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    label(.SDONE)
+	vzeroupper()
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+	  vxorps(ymm4,  ymm4,  ymm4)
+	  vmovaps(ymm4, ymm5)
+	  vmovaps(ymm4, ymm6)
+	  vmovaps(ymm4, ymm7)
+	  vmovaps(ymm4, ymm8)
+	  vmovaps(ymm4, ymm9)
+	  vmovaps(ymm4, ymm10)
+	  vmovaps(ymm4, ymm11)
+	  vmovaps(ymm4, ymm12)
+	  vmovaps(ymm4, ymm13)
+	  vmovaps(ymm4, ymm14)
+	  vmovaps(ymm4, ymm15)
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 3*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 3*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 3*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 3*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 3*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 3*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm7)
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm9)
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm11)
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+        
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+        
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx))
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm10, mem(rcx))
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+        
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+        
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    label(.SDONE)
+	vzeroupper()
+  
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+	  vxorps(ymm4,  ymm4,  ymm4)
+	  vmovaps(ymm4, ymm5)
+	  vmovaps(ymm4, ymm6)
+	  vmovaps(ymm4, ymm7)
+	  vmovaps(ymm4, ymm8)
+	  vmovaps(ymm4, ymm9)
+	  vmovaps(ymm4, ymm10)
+	  vmovaps(ymm4, ymm11)
+	  vmovaps(ymm4, ymm12)
+	  vmovaps(ymm4, ymm13)
+	  vmovaps(ymm4, ymm14)
+	  vmovaps(ymm4, ymm15)
+  
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    //lea(mem(rcx, rdi, 2), rdx)         //
+    //lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 2*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 2*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 2*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 2*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 2*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 2*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 2*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 2*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+        
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    //lea(mem(rcx, rsi, 4), rdx)         // load address of c +  4*cs_c;
+    lea(mem(rcx, rdi, 2), rdx)         // load address of c +  2*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                          // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm7)
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm9)
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm11)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm8, xmm0)//e4-e7
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e4
+    vfmadd231ps(xmm6, xmm3, xmm1)//e5
+    vfmadd231ps(xmm8, xmm3, xmm2)//e6
+    vfmadd231ps(xmm10, xmm3, xmm14)//e7
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    
+    /*********************************************/
+    vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm9, xmm0)//c0-c3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm9, xmm0)//e4-e7
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+        
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx))
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm8, xmm0)//c4-c7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    
+    /*********************************************/
+    vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm9, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm9, xmm0)//c4-c7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))        
+
+    label(.SDONE)
+	vzeroupper()
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 1*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 1*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 1*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 1*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 1*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 1*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    // ---------------------------------- iteration 2    
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    //lea(mem(rcx, rsi, 4), rdx)         // load address of c +  4*cs_c;
+    //lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm7)
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+    vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+    vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x16
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 7*8))         // prefetch c + 0*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 0*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 0*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 0*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 0*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 0*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 0*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 0*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 0*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP    
+    
+    // ---------------------------------- iteration 0    
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+        
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)    
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+        
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.    
+    
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+        
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+    vmovss(mem(rcx),xmm7)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm11)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm7, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    vextractf128(imm(0x1), ymm4, xmm0)//e4-e7
+    vmovss(mem(rcx),xmm4)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm8)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e4
+    vfmadd231ps(xmm6, xmm3, xmm1)//e5
+    vfmadd231ps(xmm8, xmm3, xmm2)//e6
+    vfmadd231ps(xmm10, xmm3, xmm14)//e7
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    vextractf128(imm(0x0), ymm5, xmm0)//c0-c3
+    vmovss(mem(rcx),xmm4)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm11)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm5, xmm0)//e4-e7
+    vmovss(mem(rcx),xmm4)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm8)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e4
+    vfmadd231ps(xmm6, xmm3, xmm1)//e5
+    vfmadd231ps(xmm8, xmm3, xmm2)//e6
+    vfmadd231ps(xmm10, xmm3, xmm14)//e7
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm4, xmm0)//e4-e7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c        
+    vextractf128(imm(0x0), ymm5, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c        
+    vextractf128(imm(0x1), ymm5, xmm0)//e4-e7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))    
+    
+    label(.SDONE)    
+    
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_6x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+        
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 5*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 5*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+        
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*16), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*16), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+        
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*16), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*16), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+        
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*16), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm14, ymm14)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                      // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm12)
+    vmovups(ymm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm14)
+    vmovups(ymm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /****6x8 tile is transposed and saved in col major as 8x6*****/    
+    vunpcklps(ymm6, ymm4, ymm0)
+    vunpcklps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vpermilpd(imm(1),xmm0,xmm5)//e1f1
+    vpermilpd(imm(1),xmm2,xmm6)//e5f5
+    vfmadd231ps(mem(rdx), xmm3, xmm0)
+    vfmadd231ps(mem(rdx, rsi, 4), xmm3, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vfmadd231ps(mem(rdx), xmm3, xmm5)
+    vfmadd231ps(mem(rdx, rsi, 4), xmm3, xmm6)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma41..gamma51 )    
+    vmovlpd(xmm6, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+    
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vpermilpd(imm(1),xmm0,xmm5)
+    vpermilpd(imm(1),xmm2,xmm6)    
+    vfmadd231ps(mem(rdx), xmm3, xmm0)
+    vfmadd231ps(mem(rdx, rsi, 4), xmm3, xmm2)    
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )    
+    lea(mem(rdx, rsi, 1), rdx)
+    vfmadd231ps(mem(rdx), xmm3, xmm5)
+    vfmadd231ps(mem(rdx, rsi, 4), xmm3, xmm6)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovlpd(xmm6, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+        
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+        
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm14, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)
+    vunpcklps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    /******************top right tile 8x2***************************/
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )    
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+    
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )    
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_5x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 5*8)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 4*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 4*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 4*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 4*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 4*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 4*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+        
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+        
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm12, ymm12)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                          // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+        
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm12)
+    vmovups(ymm12, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm8)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm8, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+    
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(ymm12, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 3*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 3*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 3*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 3*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    
+    label(.SROWSTORED)
+        
+        
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(ymm10, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+    vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+    
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )        
+    
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm1", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 2*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 2*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 2*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 2*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 2*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 2*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx, 0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 2), rdx)         // load address of c +  2*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    
+    label(.SROWSTORED)
+    
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm11)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm8, xmm0)//c0-c3
+    vmovss(mem(rdx),xmm4)
+    vmovss(mem(rdx, rsi, 1),xmm6)
+    vmovss(mem(rdx, rsi, 2),xmm11)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))    
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+    
+    /********************************************/
+    vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))
+
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm8, xmm0)//c4-c7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rdx))
+    vmovss(xmm1, mem(rdx, rsi, 1))
+    vmovss(xmm2, mem(rdx, rsi, 2))
+    vmovss(xmm14, mem(rdx, rax, 1))    
+    
+    label(.SDONE)
+    
+    
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 1*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 1*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 1*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 1*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)    
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0,xmm0,xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm2)
+    vfmadd231ps(xmm6, xmm3, xmm10)    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rsi, 1),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm11)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    
+    vmovsd(mem(rcx, rsi, 2),xmm4)
+    vmovsd(mem(rcx, rax, 1),xmm6)
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vfmadd231ps(xmm6, xmm3, xmm10)
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )    
+
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm6, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+    vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+    vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+    vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3    
+    vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+    lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+    
+    vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+    vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3        
+    vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+    vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )    
+    vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+    vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x8
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+    
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*rs_c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+        
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0,xmm0,xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /********************************************/
+    vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+    vmovss(mem(rcx),xmm8)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm11)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm8, xmm3, xmm0)//e0
+    vfmadd231ps(xmm6, xmm3, xmm1)//e1
+    vfmadd231ps(xmm11, xmm3, xmm2)//e2
+    vfmadd231ps(xmm10, xmm3, xmm14)//e3
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+
+    lea(mem(rcx, rsi, 4), rcx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm4, xmm0)//e4-e7
+    vmovss(mem(rcx),xmm4)
+    vmovss(mem(rcx, rsi, 1),xmm6)
+    vmovss(mem(rcx, rsi, 2),xmm8)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vfmadd231ps(xmm4, xmm3, xmm0)//e4
+    vfmadd231ps(xmm6, xmm3, xmm1)//e5
+    vfmadd231ps(xmm8, xmm3, xmm2)//e6
+    vfmadd231ps(xmm10, xmm3, xmm14)//e7
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))    
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(ymm4, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))
+
+    lea(mem(rcx, rsi, 4), rcx) // rdx += 4*cs_c
+
+    vextractf128(imm(0x1), ymm4, xmm0)//c4-c7
+    vshufps(imm(0x01), xmm0, xmm0,xmm1)
+    vshufps(imm(0x02), xmm0, xmm0,xmm2)
+    vshufps(imm(0x03), xmm0, xmm0,xmm14)
+    vmovss(xmm0, mem(rcx))
+    vmovss(xmm1, mem(rcx, rsi, 1))
+    vmovss(xmm2, mem(rcx, rsi, 2))
+    vmovss(xmm14, mem(rcx, rax, 1))    
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_6x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 3*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 3*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+        
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+        
+    label(.SLOOPKITER)                 // MAIN LOOP
+        
+    // ---------------------------------- iteration 0    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                      // now avoid loading C if beta == 0
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)    
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm8)
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vfmadd231ps(mem(rcx), xmm3, xmm10)
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vfmadd231ps(mem(rcx), xmm3, xmm12)
+    vmovups(xmm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm14)
+    vmovups(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm2)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm5)
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1)) 
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm7)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm9)
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1)) 
+    
+    vunpcklps(xmm14, xmm12, xmm0)//e0f0e1f1
+    vunpckhps(xmm14, xmm12, xmm1)//e2f2e3f3    
+    vmovsd(mem(rdx),xmm2)
+    vmovsd(mem(rdx, rsi, 1),xmm4)    
+    vmovsd(mem(rdx, rsi, 2),xmm6)
+    vmovsd(mem(rdx, rax, 1),xmm8)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vfmadd231ps(xmm2, xmm3, xmm0)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vfmadd231ps(xmm8, xmm3, xmm7)
+    vmovsd(xmm0, mem(rdx)) //e0f0
+    vmovsd(xmm5, mem(rdx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rdx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rdx, rax, 1)) //e3f3
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+        
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(xmm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1)) 
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3
+    
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1)) 
+    
+    vunpcklps(xmm14, xmm12, xmm0)//e0f0e1f1
+    vunpckhps(xmm14, xmm12, xmm1)//e2f2e3f3    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vmovsd(xmm0, mem(rdx)) //e0f0
+    vmovsd(xmm5, mem(rdx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rdx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rdx, rax, 1)) //e3f3    
+
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_5x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 3*8)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 4*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 4*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 4*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 4*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(r9, rsi)                       // rsi = rs_b;
+    sal(imm(5), rsi)                   // rsi = 16*rs_b;
+    lea(mem(rax, rsi, 1), rdx)         // rdx = b + 16*rs_b;
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+        
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    
+    label(.SROWSTORED)
+        
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm8)
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm10)
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm12)
+    vmovups(xmm12, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm2)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm5)
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1)) 
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm7)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm9)
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1)) 
+    
+    vmovss(mem(rdx),xmm2)
+    vmovss(mem(rdx, rsi, 1),xmm4)    
+    vmovss(mem(rdx, rsi, 2),xmm6)
+    vmovss(mem(rdx, rax, 1),xmm8)
+    vshufps(imm(0x01), xmm12, xmm12,xmm1)
+    vshufps(imm(0x02), xmm12, xmm12,xmm5)
+    vshufps(imm(0x03), xmm12, xmm12,xmm7)    
+    vfmadd231ps(xmm2, xmm3, xmm12)
+    vfmadd231ps(xmm4, xmm3, xmm1)
+    vfmadd231ps(xmm6, xmm3, xmm5)
+    vfmadd231ps(xmm8, xmm3, xmm7)
+    vmovss(xmm12, mem(rdx)) //e0
+    vmovss(xmm1, mem(rdx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rdx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rdx, rax, 1)) //e3
+
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+        
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(xmm12, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1))
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1))
+
+    vshufps(imm(0x01), xmm12, xmm12,xmm1)
+    vshufps(imm(0x02), xmm12, xmm12,xmm5)
+    vshufps(imm(0x03), xmm12, xmm12,xmm7)
+    vmovss(xmm12, mem(rdx)) //e0
+    vmovss(xmm1, mem(rdx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rdx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rdx, rax, 1)) //e3
+
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 3*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 3*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)    
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    // ---------------------------------- iteration 2    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm8)
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm10)
+    vmovups(xmm10, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm2)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm5)
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1)) 
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm7)
+    vfmadd231ps(mem(rcx, rsi, 1), xmm3, xmm9)
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1)) 
+    
+    jmp(.SDONE)                        // jump to end.
+        
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+        
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovups(xmm10, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1    
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklpd(xmm1, xmm0, xmm2)//a0b0c0d0
+    vunpckhpd(xmm1, xmm0, xmm5)//a1b1c1d1
+    vmovups(xmm2, mem(rcx))
+    vmovups(xmm5, mem(rcx, rsi, 1)) 
+    lea(mem(rcx, rsi, 2), rcx) // rcx += 2*cs_c
+    
+    vunpckhps(xmm6, xmm4, xmm0)//a2b2a3b3    
+    vunpckhps(xmm10, xmm8, xmm1)//c2d2c3d3
+    vunpcklpd(xmm1, xmm0, xmm7)//a2b2c2d2
+    vunpckhpd(xmm1, xmm0, xmm9)//a3b3c3d3    
+    vmovups(xmm7, mem(rcx))
+    vmovups(xmm9, mem(rcx, rsi, 1)) 
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 3*8)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 2*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 2*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 2*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 2*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP    
+    
+    // ---------------------------------- iteration 0    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)    
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+        
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 2), rdx)         // load address of c +  2*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm8)
+    vmovups(xmm8, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//e0f0e1f1
+    vunpckhps(xmm6, xmm4, xmm1)//e2f2e3f3    
+    vmovsd(mem(rcx),xmm2)
+    vmovsd(mem(rcx, rsi, 1),xmm4)    
+    vmovsd(mem(rcx, rsi, 2),xmm6)
+    vmovsd(mem(rcx, rax, 1),xmm10)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vfmadd231ps(xmm2, xmm3, xmm0)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vfmadd231ps(xmm10, xmm3, xmm7)
+    vmovsd(xmm0, mem(rcx)) //e0f0
+    vmovsd(xmm5, mem(rcx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rcx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rcx, rax, 1)) //e3f3
+    
+    vmovss(mem(rdx),xmm2)
+    vmovss(mem(rdx, rsi, 1),xmm4)    
+    vmovss(mem(rdx, rsi, 2),xmm6)
+    vmovss(mem(rdx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm8, xmm8,xmm1)
+    vshufps(imm(0x02), xmm8, xmm8,xmm5)
+    vshufps(imm(0x03), xmm8, xmm8,xmm7)    
+    vfmadd231ps(xmm2, xmm3, xmm8)
+    vfmadd231ps(xmm4, xmm3, xmm1)
+    vfmadd231ps(xmm6, xmm3, xmm5)
+    vfmadd231ps(xmm10, xmm3, xmm7)
+    vmovss(xmm8, mem(rdx)) //e0
+    vmovss(xmm1, mem(rdx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rdx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rdx, rax, 1)) //e3
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+
+    vmovups(xmm8, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//e0f0e1f1
+    vunpckhps(xmm6, xmm4, xmm1)//e2f2e3f3    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vmovsd(xmm0, mem(rcx)) //e0f0
+    vmovsd(xmm5, mem(rcx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rcx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rcx, rax, 1)) //e3f3
+    
+    vshufps(imm(0x01), xmm8, xmm8,xmm1)
+    vshufps(imm(0x02), xmm8, xmm8,xmm5)
+    vshufps(imm(0x03), xmm8, xmm8,xmm7)    
+    vmovss(xmm8, mem(rdx)) //e0
+    vmovss(xmm1, mem(rdx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rdx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rdx, rax, 1)) //e3
+
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 3*8)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 1*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 1*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+            
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//e0f0e1f1
+    vunpckhps(xmm6, xmm4, xmm1)//e2f2e3f3    
+    vmovsd(mem(rcx),xmm2)
+    vmovsd(mem(rcx, rsi, 1),xmm4)    
+    vmovsd(mem(rcx, rsi, 2),xmm6)
+    vmovsd(mem(rcx, rax, 1),xmm10)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vfmadd231ps(xmm2, xmm3, xmm0)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vfmadd231ps(xmm10, xmm3, xmm7)
+    vmovsd(xmm0, mem(rcx)) //e0f0
+    vmovsd(xmm5, mem(rcx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rcx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rcx, rax, 1)) //e3f3
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+        
+    label(.SROWSTORBZ)
+        
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)    
+    vmovups(xmm6, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORBZ)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//e0f0e1f1
+    vunpckhps(xmm6, xmm4, xmm1)//e2f2e3f3 
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//e1f1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//e3f3
+    vmovsd(xmm0, mem(rcx)) //e0f0
+    vmovsd(xmm5, mem(rcx, rsi, 1)) //e1f1
+    vmovsd(xmm1, mem(rcx, rsi, 2)) //e2f2
+    vmovsd(xmm7, mem(rcx, rax, 1)) //e3f3
+        
+    label(.SDONE)
+    
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x4
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 0*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 0*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(rcx, rsi, 2, 0*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 0*8))         // prefetch c + 3*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+        
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovups(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+        
+    label(.SPOSTACCUM)
+
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha    
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)    
+    
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+        
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vmovss(mem(rcx),xmm2)
+    vmovss(mem(rcx, rsi, 1),xmm6)    
+    vmovss(mem(rcx, rsi, 2),xmm8)
+    vmovss(mem(rcx, rax, 1),xmm10)
+    vshufps(imm(0x01), xmm4, xmm4,xmm1)
+    vshufps(imm(0x02), xmm4, xmm4,xmm5)
+    vshufps(imm(0x03), xmm4, xmm4,xmm7)    
+    vfmadd231ps(xmm2, xmm3, xmm4)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vfmadd231ps(xmm8, xmm3, xmm5)
+    vfmadd231ps(xmm10, xmm3, xmm7)
+    vmovss(xmm4, mem(rcx)) //e0
+    vmovss(xmm1, mem(rcx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rcx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rcx, rax, 1)) //e3
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+    
+    vmovups(xmm4, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+    
+    vshufps(imm(0x01), xmm4, xmm4,xmm1)
+    vshufps(imm(0x02), xmm4, xmm4,xmm5)
+    vshufps(imm(0x03), xmm4, xmm4,xmm7)    
+    vmovss(xmm4, mem(rcx)) //e0
+    vmovss(xmm1, mem(rcx, rsi, 1)) //e1
+    vmovss(xmm5, mem(rcx, rsi, 2)) //e2
+    vmovss(xmm7, mem(rcx, rax, 1)) //e3
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm3", "ymm4", "ymm5",
+     "ymm6", "ymm7", "ymm8", "ymm9",
+     "ymm10", "ymm11", "ymm12", "ymm13",
+     "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_6x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     ) 
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 1*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 1*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 1*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    
+
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)    
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+        
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+    
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    vmovsd(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm12)
+    vmovsd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    vmovsd(xmm14, mem(rcx))
+        
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklps(xmm14, xmm12, xmm2)//e0f0 
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vmovsd(mem(rcx, rdi, 4),xmm8)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1
+    vshufpd(imm(0x01), xmm2, xmm2, xmm9)//e1f1
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vfmadd231ps(xmm8, xmm3, xmm2)
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+    vmovsd(xmm2, mem(rcx, rdi, 4)) //e0f0
+    lea(mem(rcx, rsi, 1), rcx)
+     
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vmovsd(mem(rcx, rdi, 4),xmm8)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm7)
+    vfmadd231ps(xmm8, xmm3, xmm9)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //c1d1
+    vmovsd(xmm9, mem(rcx, rdi, 4)) //e1f1
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+
+    label(.SROWSTORBZ)
+    
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm10, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vunpcklps(xmm14, xmm12, xmm2)//e0f0
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1      
+    vshufpd(imm(0x01), xmm2, xmm2, xmm9)//e1f1     
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+    vmovsd(xmm2, mem(rcx, rdi, 4)) //e0f0
+    lea(mem(rcx, rsi, 1), rcx)
+    vmovsd(xmm5, mem(rcx)) //e0f0
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //e1f1
+    vmovsd(xmm9, mem(rcx, rdi, 4)) //e0f0
+    
+    label(.SDONE)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_5x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 1*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 1*8)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 4*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 4*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    
+    
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+                                    // now avoid loading C if beta == 0
+    
+    vxorps(xmm0, xmm0, xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    vmovsd(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm12)
+    vmovsd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+
+    vmovss(mem(rcx, rdi, 4),xmm4)
+    vshufps(imm(0x01), xmm12, xmm12, xmm9)//e1
+    vfmadd231ps(xmm4, xmm3, xmm12)
+    vmovss(xmm12,mem(rcx,rdi,4))//e0
+    
+    lea(mem(rcx, rsi, 1), rcx)     
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm7)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //c1d1
+    
+    vmovss( mem(rcx, rdi, 4),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm9)
+    vmovss(xmm9,mem(rcx,rdi,4))//e1
+
+    jmp(.SDONE)                        // jump to end.
+    
+        
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    
+    label(.SROWSTORBZ)
+    
+    vmovsd(xmm4, mem(rcx))//a0a1
+    add(rdi, rcx)
+    
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(xmm10, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(xmm12, mem(rcx))
+    add(rdi, rcx)
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+    vshufps(imm(0x01), xmm12, xmm12, xmm9)//e1
+    vmovss(xmm12,mem(rcx,rdi,4))//e0
+    
+    lea(mem(rcx, rsi, 1), rcx)     
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //c1d1    
+    vmovss(xmm9,mem(rcx,rdi,4))//e1
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(rcx, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 1*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rcx, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(rcx, 3*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 3*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    
+        
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(xmm0,xmm0,xmm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+
+    
+    label(.SROWSTORED)
+    
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)//c*beta+(a0a1)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    vmovsd(xmm10, mem(rcx))
+    
+    
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1    
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm6, xmm3, xmm1)
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+
+    lea(mem(rcx, rsi, 1), rcx)     
+    vmovsd(mem(rcx),xmm4)
+    vmovsd(mem(rcx, rdi, 2),xmm6)    
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm6, xmm3, xmm7)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //c1d1
+
+    jmp(.SDONE)                        // jump to end.
+    
+    
+    label(.SBETAZERO)
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+
+    label(.SROWSTORBZ)
+    
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(xmm8, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm10, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1
+    vshufpd(imm(0x01), xmm1, xmm1, xmm7)//c1d1
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm1, mem(rcx, rdi, 2)) //c0d0
+    lea(mem(rcx, rsi, 1), rcx)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovsd(xmm7, mem(rcx, rdi, 2)) //c1d1        
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+    
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(rcx, rdi, 2, 1*8)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 2*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 2*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+        
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx, 0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)    
+    
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx, 0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)    
+
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx, 0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)    
+
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx, 0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+        
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+    
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+        
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx, 0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)    
+    lea(mem(rcx, rdi, 2), rdx)         // load address of c +  2*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    
+                                      // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+        
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovsd(xmm8, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SCOLSTORED)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vmovsd(mem(rcx),xmm4)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vmovsd(xmm0, mem(rcx)) //a0b0    
+    vmovss(mem(rcx,rdi,2),xmm4)
+    vshufps(imm(0x01), xmm8, xmm8, xmm9)//c1
+    vfmadd231ps(xmm4, xmm3, xmm8)
+    vmovss(xmm8,mem(rcx,rdi,2))//c0
+
+    lea(mem(rcx, rsi, 1), rcx)     
+    vmovsd(mem(rcx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    
+    vmovss(mem(rcx,rdi,2),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm9)
+    vmovss(xmm9,mem(rcx,rdi,2))//c1    
+    
+    jmp(.SDONE)                        // jump to end.
+    
+    
+    label(.SBETAZERO)
+    
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+        
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+
+    vmovsd(xmm6, mem(rcx))
+    add(rdi, rcx)
+
+    vmovsd(xmm8, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1
+    vmovsd(xmm0, mem(rcx)) //a0b0    
+    vshufps(imm(0x01), xmm8, xmm8, xmm9)//c1
+    vmovss(xmm8,mem(rcx,rdi,2))//c0
+    lea(mem(rcx, rsi, 1), rcx)     
+    vmovsd(xmm5, mem(rcx)) //a1b1
+    vmovss(xmm9,mem(rcx,rdi,2))//c1    
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+    
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+    
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+        
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(rcx, rdi, 1, 1*8)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 1*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+    
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.    
+    
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+                                      // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+    
+    label(.SROWSTORED)
+        
+
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+        
+    vmovsd(mem(rcx), xmm0)////a0a1
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovsd(xmm6, mem(rcx))
+    
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORED)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vmovsd(mem(rcx),xmm4)
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    lea(mem(rcx, rsi, 1), rcx)
+    vmovsd(mem(rcx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vmovsd(xmm5, mem(rcx)) //a1b1
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+    
+    label(.SROWSTORBZ)
+    
+    vmovsd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    
+    vmovsd(xmm6, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+    
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vshufpd(imm(0x01), xmm0, xmm0, xmm5)//a1b1
+    vmovsd(xmm0, mem(rcx)) //a0b0
+    vmovsd(xmm5, mem(rcx, rsi, 1)) //a1b1
+
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2", "ymm3",
+     "ymm4", "ymm5", "ymm6", "ymm7",
+     "ymm8", "ymm9", "ymm10", "ymm11",
+     "ymm12", "ymm13", "ymm14", "ymm15",
+     "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x2
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+    
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+    
+    mov(var(a), rax)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(var(rs_b), r10)                // load rs_b
+
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+                                      // NOTE: We cannot pre-load elements of a or b
+                                      // because it could eventually, in the last
+                                      // unrolled iter or the cleanup loop, result
+                                      // in reading beyond the bounds allocated mem
+                                      // (the likely result: a segmentation fault).
+
+    mov(var(c), rcx)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(rcx, 1*8))         // prefetch c + 0*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    prefetch(0, mem(rcx, 0*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(rcx, rsi, 1, 0*8)) // prefetch c + 1*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+    
+    
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                      // contains the k_left loop.
+    
+    
+    label(.SLOOPKITER)                 // MAIN LOOP
+    
+    // ---------------------------------- iteration 0
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    // ---------------------------------- iteration 1
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    
+    // ---------------------------------- iteration 2
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    // ---------------------------------- iteration 3
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+        
+    
+    label(.SCONSIDKLEFT)
+    
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                      // else, we prepare to enter k_left loop.
+    
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+    
+    vmovsd(mem(rbx,  0*32), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm4)
+        
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+        
+    label(.SPOSTACCUM)
+    
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+    
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+    
+                                        // now avoid loading C if beta == 0
+    
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+    
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+    
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovsd(xmm4, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    vshufps(imm(0x01), xmm4, xmm4, xmm9)//c1
+    vmovss(mem(rcx),xmm6)    
+    vfmadd231ps(xmm6, xmm3, xmm4)
+    vmovss(xmm4,mem(rcx))//c0
+    vmovss(mem(rcx,rsi,1),xmm6)
+    vfmadd231ps(xmm6, xmm3, xmm9)
+    vmovss(xmm9,mem(rcx,rsi,1))//c1    
+        
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+        
+    label(.SROWSTORBZ)
+    vmovsd(xmm4, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+    
+    label(.SCOLSTORBZ)
+    
+    vshufps(imm(0x01), xmm4, xmm4, xmm9)//c1
+    vmovss(xmm4,mem(rcx))//c0
+    vmovss(xmm9,mem(rcx,rsi,1))//c1    
+    
+    label(.SDONE)
+    
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+     "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+     "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+     "xmm0", "xmm1", "xmm2", "xmm3",
+     "xmm4", "xmm5", "xmm6", "xmm7",
+     "xmm8", "xmm9", "xmm10", "xmm11",
+     "xmm12", "xmm13", "xmm14", "xmm15",
+     "ymm0", "ymm2","ymm4", "ymm5",
+     "ymm6", "ymm7", "ymm8", "ymm9",
+     "ymm10", "ymm11", "ymm12", "ymm13",
+     "ymm14", "ymm15",
+     "memory"
+    )
+}

--- a/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16m.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16m.c
@@ -1,0 +1,4077 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020 - 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16, and also make sure the
+// compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+/*
+   rrr:
+     --------        ------        --------
+     --------        ------        --------
+     --------   +=   ------ ...    --------
+     --------        ------        --------
+     --------        ------            :
+     --------        ------            :
+
+   rcr:
+     --------        | | | |       --------
+     --------        | | | |       --------
+     --------   +=   | | | | ...   --------
+     --------        | | | |       --------
+     --------        | | | |           :
+     --------        | | | |           :
+
+   Assumptions:
+   - B is row-stored;
+   - A is row- or column-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential kernel is well-suited for contiguous
+   (v)ector loads on B and single-element broadcasts from A.
+
+   NOTE: These kernels explicitly support column-oriented IO, implemented
+   via an in-register transpose. And thus they also support the crr and
+   ccr cases, though only crr is ever utilized (because ccr is handled by
+   transposing the operation and executing rcr, which does not incur the
+   cost of the in-register transpose).
+
+   crr:
+     | | | | | | | |       ------        --------
+     | | | | | | | |       ------        --------
+     | | | | | | | |  +=   ------ ...    --------
+     | | | | | | | |       ------        --------
+     | | | | | | | |       ------            :
+     | | | | | | | |       ------            :
+*/
+void bli_sgemmsup_rv_zen_asm_6x16m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    uint64_t n_left = n0 % 16;
+
+    /* For row storage format, kernel is re-written to */
+    /* use mask load/store instruction                 */
+    if ( n_left && (rs_c0 != 1))
+    {
+        float* restrict cij = (float *)c;
+        float* restrict bj  = (float *)b;
+        float* restrict ai  = (float *)a;
+        /**************************************************************************/
+        /* Mask load and store support is added for fringe cases                  */
+        /* Fringe cases are the numbers which not multiple of xmm or ymm register */
+        /* n_left : 15,14,13,11,10,9,7,6,5,3                                      */
+        /* When mask register values are set, load/store is performed             */
+        /* When mask register values are not set, load/store is not performed     */
+        /*Elements: 1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16*/
+        /*n0=16   : -----------ymm---------------  -----------ymm---------------- */
+        /*n0=15   : -----------ymm---------------   -1  -1  -1  -1  -1  -1  -1  0 */
+        /*n0=14   : -----------ymm---------------   -1  -1  -1  -1  -1  -1   0  0 */
+        /*n0=9    : -----------ymm---------------   -1   0   0   0   0   0   0  0 */
+        /*n0=8    : -----------ymm---------------   -----------Not used---------  */
+        /*n0=7    : -1  -1  -1  -1  -1  -1  -1  0   -----------Not used---------  */
+        /*n0=3    : -1  -1  -1   0   0   0   0  0   -----------Not used---------  */
+        /*Same code can be resued for multiple n_left by just varing mask register*/
+        /*We will be able to perform complete operation of tile with this approach*/
+        /**************************************************************************/
+        switch(n_left)
+        {
+          /*Fringe cases*/
+            case 15: case 14: case 13:
+            case 11: case 10: case 9:
+            {
+                const dim_t nr_cur = n_left;
+                /**********************************************/
+                /* These case is executed when nleft - 9 to 15*/
+                /* 16 Elements in col order                   */
+                /*   ---YMM REG-----    ---YMM Mask Reg---    */
+                /*   0 1 2 3 4 5 6 7   8 9 10 11 12 13 14 15  */
+                /*15:0 1 2 3 4 5 6 7   8 9 10 11 12 13 14 x   */
+                /*14:0 1 2 3 4 5 6 7   8 9 10 11 12 13  x x   */
+                /*11:0 1 2 3 4 5 6 7   8 9 10  x  x  x  x x   */
+                /* and so on                                  */
+                /**********************************************/
+                bli_sgemmsup_rv_zen_asm_6x16m_mask
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+            case 7: case 6: case 5:
+            {
+               /***********************************************/
+                /* These case is executed when nleft - 5 to 7 */
+                /* 8 Elements in col order                    */
+                /*       YMM Mask REG                         */
+                /*      0 1 2 3 4 5 6 7                       */
+                /*7:    0 1 2 3 4 5 6 x                       */
+                /*6:    0 1 2 3 4 5 x x                       */
+                /*5:    0 1 2 3 4 x x x                       */
+                /**********************************************/
+                const dim_t nr_cur = n_left;
+
+                bli_sgemmsup_rv_zen_asm_6x8m_mask
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+            case 3: case 1:
+            {
+               /***********************************************/
+                /* These case is executed when nleft - 3/1    */
+                /* 4 Elements in col order                    */
+                /*      XMM Mask REG                         */
+                /*      0 1 2 3                               */
+                /*3:    0 1 2 x                               */
+                /*1:    0 x x x                               */
+                /**********************************************/
+                const dim_t nr_cur = n_left;
+                bli_sgemmsup_rv_zen_asm_6x4m_mask
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+            /*Non-Fringe cases*/
+            case 12:
+            {
+              #if 0
+                const dim_t nr_cur = 12;
+                bli_sgemmsup_rv_haswell_asm_6x12m
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+              #endif
+
+              dim_t nr_cur = 8;
+
+              bli_sgemmsup_rv_zen_asm_6x8m
+              (
+                conja, conjb, m0, nr_cur, k0,
+                alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                beta, cij, rs_c0, cs_c0, data, cntx
+              );
+              cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+
+              nr_cur = 4;
+              bli_sgemmsup_rv_zen_asm_6x4m
+              (
+                conja, conjb, m0, nr_cur, k0,
+                alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                beta, cij, rs_c0, cs_c0, data, cntx
+              );
+              break;
+
+            }
+            case 8:
+            {
+                const dim_t nr_cur = 8;
+
+                bli_sgemmsup_rv_zen_asm_6x8m
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+            case 4:
+            {
+                const dim_t nr_cur = 4;
+
+                bli_sgemmsup_rv_zen_asm_6x4m
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+            case 2:
+            {
+                const dim_t nr_cur = 2;
+
+                bli_sgemmsup_rv_zen_asm_6x2m
+                (
+                  conja, conjb, m0, nr_cur, k0,
+                  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+                  beta, cij, rs_c0, cs_c0, data, cntx
+                );
+                break;
+            }
+        default:
+        break;
+        }
+        return;
+    }
+
+    // First check whether this is a edge case in the n dimension. If so,
+    // dispatch other 6x?m kernels, as needed.
+    if (n_left )
+    {
+        float*  cij = (float *)c;
+        float*  bj  = (float *)b;
+        float*  ai  = (float *)a;
+
+        if ( 8 <= n_left )
+        {
+            const dim_t nr_cur = 8;
+
+            bli_sgemmsup_rv_zen_asm_6x8m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+
+        if ( 4 <= n_left )
+        {
+            const dim_t nr_cur = 4;
+
+            bli_sgemmsup_rv_zen_asm_6x4m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+
+        if ( 2 <= n_left )
+        {
+            const dim_t nr_cur = 2;
+
+            bli_sgemmsup_rv_zen_asm_6x2m
+            (
+              conja, conjb, m0, nr_cur, k0,
+              alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+              beta, cij, rs_c0, cs_c0, data, cntx
+            );
+            cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+        }
+
+        if ( 1 == n_left )
+        {
+            dim_t ps_a0 = bli_auxinfo_ps_a( data );
+            if ( ps_a0 == 6 * rs_a0 )
+            {
+                bli_sgemv_ex
+                (
+                    BLIS_NO_TRANSPOSE, conjb, m0, k0,
+                    alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+                    beta, cij, rs_c0, cntx, NULL
+                );
+            }
+            else
+            {
+                const dim_t mr = 6;
+
+                // Since A is packed into row panels, we must use a loop over
+                // gemv.
+                dim_t m_iter = ( m0 + mr - 1 ) / mr;
+                dim_t m_left =   m0            % mr;
+
+                float* restrict ai_ii  = ai;
+                float* restrict cij_ii = cij;
+
+                for ( dim_t ii = 0; ii < m_iter; ii += 1 )
+                {
+                    dim_t mr_cur = ( bli_is_not_edge_f( ii, m_iter, m_left )
+                                     ? mr : m_left );
+
+                    bli_sgemv_ex
+                    (
+                      BLIS_NO_TRANSPOSE, conjb, mr_cur, k0,
+                      alpha, ai_ii, rs_a0, cs_a0, bj, rs_b0,
+                      beta, cij_ii, rs_c0, cntx, NULL
+                    );
+                    cij_ii += mr*rs_c0; ai_ii += ps_a0;
+                }
+            }
+        }
+
+        return;
+    }
+
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+
+
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(dt)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(dt)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(dt)
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(dt)
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X16I)                 // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    mov(var(b), rbx)                   // load address of b.
+    //mov(r12, rcx)                    // reset rcx to current utile of c.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored pre-fetching on c // not used
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 7*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 7*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of pre-fetching c
+    label(.SCOLPFETCH)                 // column-stored pre-fetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(dt)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))        // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+    lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 7*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for pre-fetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+    lea(mem(rdx, r9,  4), rdx)         // a_prefetch += 4*cs_a;
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmovups(mem(rbx, 1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmovups(mem(rbx,  0*32), ymm0)
+    vmovups(mem(rbx,  1*32), ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+    vfmadd231ps(ymm1, ymm3, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+    vfmadd231ps(ymm1, ymm3, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+    vfmadd231ps(ymm1, ymm3, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm13, ymm13)
+    vmulps(ymm0, ymm14, ymm14)
+    vmulps(ymm0, ymm15, ymm15)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(dt)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm5)
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm7)
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm9)
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm11)
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm12)
+    vmovups(ymm12, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm13)
+    vmovups(ymm13, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vfmadd231ps(mem(rcx), ymm3, ymm14)
+    vmovups(ymm14, mem(rcx))
+
+    vfmadd231ps(mem(rcx, rsi, 8), ymm3, ymm15)
+    vmovups(ymm15, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+
+
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORED)
+
+  /*|-----------------|              |-----|----|
+    |         |       |              | 8x4 | 8x2|
+    |    4x8  |   4x8 |              |     |    |
+    |         |       |              |-----|----|
+    |-----------------|              | 8x4 | 8x2|
+    |    2x8  |   2x8 |              |     |    |
+    |------------------              |----------|*/
+
+    /****6x16 tile is transposed and saved in col major as 6x16*****/
+    /****top left tile 4x8 transposed to top left tile 8x4**********/
+    vunpcklps(ymm6, ymm4, ymm0)//a0b0a1b1 a4b4a5b5
+    vunpcklps(ymm10, ymm8, ymm1)//c0d0c1d1 c4d4c5d5
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)//a1b1c0d0 a5b5c4d4
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)//a0b0c0d0 a4b4c4d4
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)//a1b1c1d1 a5b5c5d5
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+    /***bottom left tile - 2x8 is transposed to top right tile 8x2**********/
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma41..gamma51 )
+    lea(mem(rdx, rsi, 4), rax) // rax += 4*cs_c
+
+    vmovlpd(mem(rax), xmm1, xmm1)
+    vmovhpd(mem(rax, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm2, mem(rax)) // store ( gamma44..gamma54 )
+    vmovhpd(xmm2, mem(rax, rsi, 1)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c
+
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma43..gamma53 )
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm2, mem(rdx)) // store ( gamma46..gamma56 )
+    vmovhpd(xmm2, mem(rdx, rsi, 1)) // store ( gamma47..gamma57 )
+
+    lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c
+
+    /***top right tile  4x8 is transposed to bottom left tile 8x4**********/
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    //lea(mem(rcx, rsi, 8), rcx) // rcx += 8*cs_c
+    /*** bottom right 2x8 is transposed to bottom right tile 8x2*******/
+    vunpcklps(ymm15, ymm13, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma41..gamma51 )
+    lea(mem(rdx, rsi, 4), rax) // rax += 4*cs_c
+
+    vmovlpd(mem(rax), xmm1, xmm1)
+    vmovhpd(mem(rax, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm2, mem(rax)) // store ( gamma44..gamma54 )
+    vmovhpd(xmm2, mem(rax, rsi, 1)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c
+
+    vunpckhps(ymm15, ymm13, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma43..gamma53 )
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+    vmovlpd(mem(rdx), xmm1, xmm1)
+    vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm2, mem(rdx)) // store ( gamma46..gamma56 )
+    vmovhpd(xmm2, mem(rdx, rsi, 1)) // store ( gamma47..gamma57 )
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx))
+    vmovups(ymm5, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vmovups(ymm6, mem(rcx))
+    vmovups(ymm7, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vmovups(ymm8, mem(rcx))
+    vmovups(ymm9, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vmovups(ymm10, mem(rcx))
+    vmovups(ymm11, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vmovups(ymm12, mem(rcx))
+    vmovups(ymm13, mem(rcx, rsi, 8))
+    add(rdi, rcx)
+
+
+    vmovups(ymm14, mem(rcx))
+    vmovups(ymm15, mem(rcx, rsi, 8))
+    //add(rdi, rcx)
+
+    jmp(.SDONE)                        // jump to end.
+
+
+    label(.SCOLSTORBZ)
+    /****6x16 tile going to save into 16x6 tile in C*****/
+    /******************top left tile 8x4***************************/
+    vunpcklps(ymm6, ymm4, ymm0)
+    vunpcklps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+    /******************top right tile 8x2***************************/
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+    lea(mem(rdx, rsi, 1), rdx)
+    lea(mem(rdx, rsi, 4), rdx) // rdx += 8*cs_c
+
+    /******************bottom left tile 8x4***************************/
+    vunpcklps(ymm7, ymm5, ymm0)
+    vunpcklps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm7, ymm5, ymm0)
+    vunpckhps(ymm11, ymm9, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    /******************bottom right tile 8x2***************************/
+    vunpcklps(ymm15, ymm13, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+
+    vunpckhps(ymm15, ymm13, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    //lea(mem(r14, r8,  4), r14)         //
+    //lea(mem(r14, r8,  2), r14)         // a_ii = r14 += 6*rs_a
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X16I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [ps_a4]  "m" (ps_a4),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm5", "ymm6", "ymm7",
+      "ymm8", "ymm9", "ymm10", "ymm11",
+      "ymm12", "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 16;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float*  restrict cij = (float *)c + i_edge*rs_c;
+        float*  restrict ai  = (float *)a + m_iter*ps_a;
+        float*  restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+        {
+          NULL,
+          bli_sgemmsup_rv_zen_asm_1x16,
+          bli_sgemmsup_rv_zen_asm_2x16,
+          bli_sgemmsup_rv_zen_asm_3x16,
+          bli_sgemmsup_rv_zen_asm_4x16,
+          bli_sgemmsup_rv_zen_asm_5x16
+        };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+        return;
+
+    }
+}
+
+void bli_sgemmsup_rv_zen_asm_6x8m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X8I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+                                       // skylake can execute 3 vxorpd ipc with
+                                       // a latency of 1 cycle, while vzeroall
+                                       // has a latency of 12 cycles.
+    vxorps(ymm1,  ymm1,  ymm1)         // zero ymm1 since we only use the lower
+    vxorps(ymm4,  ymm4,  ymm4)         // half (xmm1), and nans/infs may slow us down.
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm14, ymm14, ymm14)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 5*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 5*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmovups(mem(rbx), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmovups(mem(rbx), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmovups(mem(rbx), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmovups(mem(rbx), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmovups(mem(rbx), ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vbroadcastss(mem(rax, r8,  1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm0, ymm3, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vbroadcastss(mem(rax, r13, 1), ymm3)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm0, ymm3, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vbroadcastss(mem(rax, r15, 1), ymm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm0, ymm3, ymm14)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm14, ymm14)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), ymm3, ymm4)
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), ymm3, ymm6)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), ymm3, ymm8)
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), ymm3, ymm10)
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), ymm3, ymm12)
+    vmovups(ymm12, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), ymm3, ymm14)
+    vmovups(ymm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /****6x8 tile is transposed and saved in col major as 8x6*****/
+    vunpcklps(ymm6, ymm4, ymm0)
+    vunpcklps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vpermilps(imm(0xe),xmm0,xmm5)
+    vpermilps(imm(0xe),xmm2,xmm6)
+    vmovq(mem(rdx),xmm4)
+    vmovq(mem(rdx, rsi, 4),xmm1)
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovq(mem(rdx),xmm4)
+    vmovq(mem(rdx, rsi, 4),xmm1)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma41..gamma51 )
+    vmovlpd(xmm6, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vpermilps(imm(0xe),xmm0,xmm5)
+    vpermilps(imm(0xe),xmm2,xmm6)
+    vmovq(mem(rdx),xmm4)
+    vmovq(mem(rdx, rsi, 4),xmm1)
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vfmadd231ps(xmm1, xmm3, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovq(mem(rdx),xmm4)
+    vmovq(mem(rdx, rsi, 4),xmm1)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovlpd(xmm6, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm6, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm8, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm10, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm12, mem(rcx))
+    add(rdi, rcx)
+    vmovups(ymm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(ymm6, ymm4, ymm0)
+    vunpcklps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(ymm6, ymm4, ymm0)
+    vunpckhps(ymm10, ymm8, ymm1)
+    vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+    vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+    vblendps(imm(0x33), ymm2, ymm1, ymm1)
+
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vextractf128(imm(0x1), ymm1, xmm2)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+    vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+    /******************top right tile 8x2***************************/
+    vunpcklps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+    lea(mem(rdx, rsi, 1), rdx)
+
+    vunpckhps(ymm14, ymm12, ymm0)
+    vextractf128(imm(0x1), ymm0, xmm2)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+    vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    //lea(mem(r14, r8,  4), r14)         //
+    //lea(mem(r14, r8,  2), r14)         // a_ii = r14 += 6*rs_a
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X8I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [ps_a4]  "m" (ps_a4),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "ymm0", "ymm1", "ymm2", "ymm3",
+      "ymm4", "ymm6", "ymm8", "ymm10",
+      "ymm12", "ymm14",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 8;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter*ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+        {
+          NULL,
+          bli_sgemmsup_rv_zen_asm_1x8,
+          bli_sgemmsup_rv_zen_asm_2x8,
+          bli_sgemmsup_rv_zen_asm_3x8,
+          bli_sgemmsup_rv_zen_asm_4x8,
+          bli_sgemmsup_rv_zen_asm_5x8
+        };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+        return;
+    }
+}
+
+void bli_sgemmsup_rv_zen_asm_6x4m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    // During preamble and loops:
+    // r12 = rcx = c    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+    vxorps(xmm10, xmm10, xmm10)
+    vxorps(xmm12, xmm12, xmm12)
+    vxorps(xmm14, xmm14, xmm14)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 5*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 5*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmovups(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmovups(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmovups(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmovups(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmovups(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm6)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm8)
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm10)
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm12)
+    vmovups(xmm12, mem(rcx))
+    add(rdi, rcx)
+    vfmadd231ps(mem(rcx), xmm3, xmm14)
+    vmovups(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /****6x4 tile is transposed and saved in col major as 4x6*****/
+    vunpcklps(xmm6, xmm4, xmm0)
+    vunpcklps(xmm10, xmm8, xmm1)
+    vshufps(imm(0x4e), xmm1, xmm0, xmm2)
+    vblendps(imm(0xcc), xmm2, xmm0, xmm0)
+    vblendps(imm(0x33), xmm2, xmm1, xmm1)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+
+    vunpckhps(xmm6, xmm4, xmm0)
+    vunpckhps(xmm10, xmm8, xmm1)
+    vshufps(imm(0x4e), xmm1, xmm0, xmm2)
+    vblendps(imm(0xcc), xmm2, xmm0, xmm0)
+    vblendps(imm(0x33), xmm2, xmm1, xmm1)
+    vfmadd231ps(mem(rcx), xmm3, xmm0)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vfmadd231ps(mem(rcx), xmm3, xmm1)
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+
+    vunpcklps(xmm14, xmm12, xmm0)
+    vpermilps(imm(0x4e), xmm0, xmm5)
+    vmovq(mem(rdx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovq(mem(rdx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma41..gamma51 )
+
+    lea(mem(rdx, rsi, 1), rdx)
+    vunpckhps(xmm14, xmm12, xmm0)
+    vpermilps(imm(0x4e), xmm0, xmm5)
+    vmovq(mem(rdx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovq(mem(rdx),xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma43..gamma53 )
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm8, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm10, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm12, mem(rcx))
+    add(rdi, rcx)
+    vmovups(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)
+    vunpcklps(xmm10, xmm8, xmm1)
+    vshufps(imm(0x4e), xmm1, xmm0, xmm2)
+    vblendps(imm(0xcc), xmm2, xmm0, xmm0)
+    vblendps(imm(0x33), xmm2, xmm1, xmm1)
+    vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vunpckhps(xmm6, xmm4, xmm0)
+    vunpckhps(xmm10, xmm8, xmm1)
+    vshufps(imm(0x4e), xmm1, xmm0, xmm2)
+    vblendps(imm(0xcc), xmm2, xmm0, xmm0)
+    vblendps(imm(0x33), xmm2, xmm1, xmm1)
+    vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+
+    vunpcklps(xmm14, xmm12, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vunpckhps(xmm14, xmm12, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    //lea(mem(r14, r8,  4), r14)         //
+    //lea(mem(r14, r8,  2), r14)         // a_ii = r14 += 6*rs_a
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X4I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [ps_a4]  "m" (ps_a4),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 4;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter*ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+        {
+          NULL,
+          bli_sgemmsup_rv_zen_asm_1x4,
+          bli_sgemmsup_rv_zen_asm_2x4,
+          bli_sgemmsup_rv_zen_asm_3x4,
+          bli_sgemmsup_rv_zen_asm_4x4,
+          bli_sgemmsup_rv_zen_asm_5x4
+        };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+        return;
+    }
+}
+
+void bli_sgemmsup_rv_zen_asm_6x2m
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    // During preamble and loops:
+    // r12 = rcx = c    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X2I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+    vxorps(xmm10, xmm10, xmm10)
+    vxorps(xmm12, xmm12, xmm12)
+    vxorps(xmm14, xmm14, xmm14)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 5*8)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 5*8)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 5*8)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 5*8)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+    vmovq(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmovq(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmovq(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmovq(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmovq(mem(rbx), xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmovlpd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+    vmovlpd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmovlpd(xmm8, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+    vmovlpd(xmm10, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm12)
+    vmovlpd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    vmovsd(mem(rcx), xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+    vmovlpd(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /****6x2 tile is transposed and saved in col major as 2x6*****/
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vshufps(imm(0x44), xmm1, xmm0, xmm2) //01-00-01-00
+    vshufps(imm(0xee), xmm1, xmm0, xmm4) //11-10-11-10
+
+    vfmadd231ps(mem(rcx), xmm3, xmm2)
+    vmovupd(xmm2, mem(rcx)) // store ( gamma00..gamma30 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vfmadd231ps(mem(rcx), xmm3, xmm4)
+    vmovupd(xmm4, mem(rcx)) // store ( gamma01..gamma31 )
+
+    vunpcklps(xmm14, xmm12, xmm0)//eof0e1f1
+    vpermilps(imm(0x4e),xmm0,xmm5)
+    vmovq(mem(rdx), xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm0)
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovq(mem(rdx), xmm4)
+    vfmadd231ps(xmm4, xmm3, xmm5)
+    vmovlpd(xmm5, mem(rdx)) // store ( gamma41..gamma51 )
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovlpd(xmm4, mem(rcx))
+    add(rdi, rcx)
+    vmovlpd(xmm6, mem(rcx))
+    add(rdi, rcx)
+    vmovlpd(xmm8, mem(rcx))
+    add(rdi, rcx)
+    vmovlpd(xmm10, mem(rcx))
+    add(rdi, rcx)
+    vmovlpd(xmm12, mem(rcx))
+    add(rdi, rcx)
+    vmovlpd(xmm14, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    vunpcklps(xmm6, xmm4, xmm0)//a0b0a1b1
+    vunpcklps(xmm10, xmm8, xmm1)//c0d0c1d1
+    vshufps(imm(0x44), xmm1, xmm0, xmm2) //01-00-01-00
+    vshufps(imm(0xee), xmm1, xmm0, xmm4) //11-10-11-10
+
+    vmovupd(xmm2, mem(rcx)) // store ( gamma00..gamma30 )
+    lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+    vmovupd(xmm4, mem(rcx)) // store ( gamma01..gamma31 )
+
+    vunpcklps(xmm14, xmm12, xmm0)//eof0e1f1
+    vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+    lea(mem(rdx, rsi, 1), rdx)
+    vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    //lea(mem(r14, r8,  4), r14)         //
+    //lea(mem(r14, r8,  2), r14)         // a_ii = r14 += 6*rs_a
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X2I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter] "m" (m_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [ps_a4]  "m" (ps_a4),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm5", "xmm6", "xmm7",
+      "xmm8", "xmm9", "xmm10", "xmm11",
+      "xmm12", "xmm13", "xmm14", "xmm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = 2;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter*ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+        {
+          NULL,
+          bli_sgemmsup_rv_zen_asm_1x2,
+          bli_sgemmsup_rv_zen_asm_2x2,
+          bli_sgemmsup_rv_zen_asm_3x2,
+          bli_sgemmsup_rv_zen_asm_4x2,
+          bli_sgemmsup_rv_zen_asm_5x2
+        };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+        return;
+    }
+}
+
+/* Mask elements to specify how many elements to be loaded from C buffer */
+static const int32_t mask[8][8] = { {0, 0, 0, 0, 0, 0, 0, 0}, //load no values, not used currently
+                                    {-1, 0, 0, 0, 0, 0, 0, 0}, // load 1 value from memory
+                                    {-1, -1, 0, 0, 0, 0, 0, 0}, // load 2 values from memory
+                                    {-1, -1, -1, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, -1, 0},
+                                  };
+
+void bli_sgemmsup_rv_zen_asm_6x16m_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // This kernel is called when n_left is greater than 8. This kernel operates 16 columns at time.
+    // First 8 elements can be loaded directly and next elements will be loaded based the mask reg
+    //
+    // Sets up the mask for loading relevant remainder elements in load direction
+    //
+    // ______ymm0______  __________ymm1_________
+    // | | | | | | | | | | | |  |  |  |  |  |  |
+    // |0|1|2|3|4|5|6|7| |8|9|10|11|12|13|14|15|    ----> Source vector
+    // |_|_|_|_|_|_|_|_| |_|_|__|__|__|__|__|__|
+    //
+    // ________________  ______ymm3_______
+    // | | | | | | | | | | | | | | | | | |
+    // |NoMASK Required| |x|x|x|x|x|x|x|x|  ----> Mask vector[x can be -1/0]
+    // |_|_|_|_|_|_|_|_| |_|_|_|_|_|_|_|_|
+    //
+    // For example when n_left = 13
+    // ________________  ________ymm3__________
+    // | | | | | | | | | |  |  |  |  |  | | | |
+    // |NoMASK Required| |-1|-1|-1|-1|-1|0|0|0|  ----> Mask vector
+    // |_|_|_|_|_|_|_|_| |__|__|__|__|__|_|_|_|
+    //
+    // ______ymm0_______  ________ymm1__________
+    // | | | | | | | | | | | |  |  |  |  |  |  |
+    // |0|1|2|3|4|5|6|7| |8|9|10|11|12|0 |0 |0 |  ----> Destination vector
+    // |_|_|_|_|_|_|_|_| |_|_|__|__|__|__|__|__|
+    //
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)           //load mask values
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X15I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+                                       // skylake can execute 3 vxorps ipc with
+                                       // a latency of 1 cycle, while vzeroall
+                                       // has a latency of 12 cycles.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm5,  ymm5,  ymm5)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm7,  ymm7,  ymm7)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm9,  ymm9,  ymm9)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm11, ymm11, ymm11)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm13, ymm13, ymm13)
+    vxorps(ymm14, ymm14, ymm14)
+    vxorps(ymm15, ymm15, ymm15)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,         8*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 8*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 8*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,         8*4)) // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 8*4)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 8*4)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+
+    prefetch(0, mem(rdx, 5*8))
+
+    vmovups(mem(rbx, 0*32), ymm0)      //load first 8 elements
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1) //load next required elements
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+    vfmadd231ps(ymm1, ymm2, ymm15)
+
+    // ---------------------------------- iteration 1
+
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+    vfmadd231ps(ymm1, ymm2, ymm15)
+
+    // ---------------------------------- iteration 2
+
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+    vfmadd231ps(ymm1, ymm2, ymm15)
+
+    // ---------------------------------- iteration 3
+
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+    lea(mem(rdx, r9,  4), rdx)         // a_prefetch += 4*cs_a;
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+    vfmadd231ps(ymm1, ymm2, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+    vfmadd231ps(ymm1, ymm2, ymm15)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm1)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm13, ymm13)
+    vmulps(ymm0, ymm14, ymm14)
+    vmulps(ymm0, ymm15, ymm15)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm1)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))    //store only required elements
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm6)
+    vmovups(ymm6, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm7)
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm8)
+    vmovups(ymm8, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm9)
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm10)
+    vmovups(ymm10, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm11)
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm12)
+    vmovups(ymm12, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm13)
+    vmaskmovps(ymm13, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm14)
+    vmovups(ymm14, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm15)
+    vmaskmovps(ymm15, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support */
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))    //Store only required elements
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx, 0*32))
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx, 0*32))
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm10, mem(rcx, 0*32))
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm12, mem(rcx, 0*32))
+    vmaskmovps(ymm13, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm14, mem(rcx, 0*32))
+    vmaskmovps(ymm15, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X15I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]     "m"   (m_iter),
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6",
+      "ymm7", "ymm8", "ymm9", "ymm10", "ymm11", "ymm12",
+      "ymm13", "ymm14", "ymm15",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = n0;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter * ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+            {
+              NULL,
+              bli_sgemmsup_rv_zen_asm_1x16_mask,
+              bli_sgemmsup_rv_zen_asm_2x16_mask,
+              bli_sgemmsup_rv_zen_asm_3x16_mask,
+              bli_sgemmsup_rv_zen_asm_4x16_mask,
+              bli_sgemmsup_rv_zen_asm_5x16_mask
+            };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+
+        return;
+    }
+}
+
+void bli_sgemmsup_rv_zen_asm_6x8m_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // This kernel is called when n_left 7, 6, 5. This kernel operates 8 columns at time.
+    //
+    // Sets up the mask for loading relevant remainder elements in load direction
+    //
+    // ______ymm0_______
+    // | | | | | | | | |
+    // |0|1|2|3|4|5|6|7|   ----> Source vector
+    // |_|_|_|_|_|_|_|_|
+    //
+    //______ymm3_______
+    //| | | | | | | | |
+    //|x|x|x|x|x|x|x|x|  ----> Mask vector[x can be -1/0]
+    //|_|_|_|_|_|_|_|_|
+    //
+    // For example when n_left = 6
+    // ________ymm3__________
+    // |  |  |  |  |  |  | | |
+    // |-1|-1|-1|-1|-1|-1|0|0|  ----> Mask vector
+    // |__|__|__|__|__|__|_|_|
+    //
+    // _______ymm0______
+    // | | | | | | | | |
+    // |0|1|2|3|4|5|0|0|  ----> Destination vector
+    // |_|_|_|_|_|_|_|_|
+    //
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)            //load mask values
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X7I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+                                       // skylake can execute 3 vxorps ipc with
+                                       // a latency of 1 cycle, while vzeroall
+                                       // has a latency of 12 cycles.
+    vxorps(ymm4,  ymm4,  ymm4)
+    vxorps(ymm6,  ymm6,  ymm6)
+    vxorps(ymm8,  ymm8,  ymm8)
+    vxorps(ymm10, ymm10, ymm10)
+    vxorps(ymm12, ymm12, ymm12)
+    vxorps(ymm14, ymm14, ymm14)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,         4*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 4*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 4*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,         4*4)) // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 4*4)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 4*4)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0) //load  required elements
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+
+    // ---------------------------------- iteration 1
+
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+
+    // ---------------------------------- iteration 2
+
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+
+    // ---------------------------------- iteration 3
+
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+    lea(mem(rdx, r9,  4), rdx)         // a_prefetch += 4*cs_a;
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vbroadcastss(mem(rax, r15, 1), ymm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(ymm0, ymm2, ymm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm1)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm14, ymm14)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm1)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm6)
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm8)
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm10)
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm12)
+    vmaskmovps(ymm12, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm14)
+    vmaskmovps(ymm14, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm12, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm14, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X7I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]     "m"   (m_iter),
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm6",
+      "ymm8", "ymm10", "ymm12", "ymm14",
+      "memory"
+    )
+
+    consider_edge_cases:
+    // Handle edge cases in the m dimension, if they exist.
+    if (m_left )
+    {
+        const dim_t      nr_cur = n0;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter * ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+            {
+              NULL,
+              bli_sgemmsup_rv_zen_asm_1x8_mask,
+              bli_sgemmsup_rv_zen_asm_2x8_mask,
+              bli_sgemmsup_rv_zen_asm_3x8_mask,
+              bli_sgemmsup_rv_zen_asm_4x8_mask,
+              bli_sgemmsup_rv_zen_asm_5x8_mask
+            };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+
+        return;
+    }
+}
+
+void bli_sgemmsup_rv_zen_asm_6x4m_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+    uint64_t m_left = m0 % 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    // This kernel is called when n_left is 3/1. This kernel operates 4 columns at time.
+    //
+    // Sets up the mask for loading relevant remainder elements in load direction
+    //
+    // __xmm0___
+    // | | | | |
+    // |0|1|2|3|   ----> Source vector
+    // |_|_|_|_|
+    //
+    // __xmm7___
+    // | | | | |
+    // |x|x|x|x|  ----> Mask vector[x can be -1/0]
+    // |_|_|_|_|
+    //
+    // For example when n_left = 3
+    // ___xmm7_____
+    // |  |  |  | |
+    // |-1|-1|-1|0|  ----> Mask vector
+    // |__|__|__|_|
+    //
+    // For example when n_left = 1
+    // ___xmm7___
+    // |  | | | |
+    // |-1|0|0|0|  ----> Mask vector
+    // |__|_|_|_|
+    //
+    // __xmm0___
+    // | | | | |
+    // |0|1|2|3|  ----> Destination vector
+    // |_|_|_|_|
+    //
+    const int32_t *mask_vec = mask[n0];
+
+    if ( m_iter == 0 ) goto consider_edge_cases;
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)           //load mask values
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+    lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    // During preamble and loops:
+    // r12 = rcx = c    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+    // r11 = m dim index ii
+
+    mov(var(m_iter), r11)              // ii = m_iter;
+
+    label(.SLOOP6X4I)                  // LOOP OVER ii = [ m_iter ... 1 0 ]
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+    vxorps(xmm10, xmm10, xmm10)
+    vxorps(xmm12, xmm12, xmm12)
+    vxorps(xmm14, xmm14, xmm14)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 0)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 0)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 0))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 0)) // prefetch c + 4*rs_c
+    prefetch(0, mem(rdx, rdi, 2, 0)) // prefetch c + 5*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    vbroadcastss(mem(rax, r15, 1), xmm3)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+    vfmadd231ps(xmm0, xmm3, xmm14)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+    vmulps(xmm0, xmm14, xmm14)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm10)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm12)
+    vmaskmovps(xmm12, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm14)
+    vmaskmovps(xmm14, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm12, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm14, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    lea(mem(r12, rdi, 4), r12)         //
+    lea(mem(r12, rdi, 2), r12)         // c_ii = r12 += 6*rs_c
+
+    mov(var(ps_a4), rax)               // load ps_a4
+    lea(mem(r14, rax, 1), r14)         // a_ii = r14 += ps_a4
+
+    dec(r11)                           // ii -= 1;
+    jne(.SLOOP6X4I)                    // iterate again if ii != 0.
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]     "m"   (m_iter),
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm6", "xmm7",
+      "xmm8", "xmm10", "xmm12", "xmm14",
+      "memory"
+    )
+
+    consider_edge_cases:
+
+    // Handle edge cases in the m dimension, if they exist.
+    if ( m_left )
+    {
+        const dim_t      nr_cur = n0;
+        const dim_t      i_edge = m0 - ( dim_t )m_left;
+
+        float* restrict cij = (float *)c + i_edge*rs_c;
+        float* restrict ai  = (float *)a + m_iter*ps_a;
+        float* restrict bj  = (float *)b;
+
+        gemmsup_ker_ft ker_fps[6] =
+        {
+          NULL,
+          bli_sgemmsup_rv_zen_asm_1x4_mask,
+          bli_sgemmsup_rv_zen_asm_2x4_mask,
+          bli_sgemmsup_rv_zen_asm_3x4_mask,
+          bli_sgemmsup_rv_zen_asm_4x4_mask,
+          bli_sgemmsup_rv_zen_asm_5x4_mask
+        };
+
+        gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+
+        ker_fp
+        (
+          conja, conjb, m_left, nr_cur, k0,
+          alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+          beta, cij, rs_c0, cs_c0, data, cntx
+        );
+        return;
+    }
+}

--- a/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16n.c
+++ b/kernels/zen/3/sup/bli_gemmsup_rv_zen_asm_s6x16n.c
@@ -1,0 +1,3890 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2021 - 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16, and also make sure the
+// compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+/*
+   rrr:
+	 --------        ------        --------      
+	 --------        ------        --------      
+	 --------   +=   ------ ...    --------      
+	 --------        ------        --------      
+	 --------        ------            :         
+	 --------        ------            :         
+
+   rcr:
+	 --------        | | | |       --------      
+	 --------        | | | |       --------      
+	 --------   +=   | | | | ...   --------      
+	 --------        | | | |       --------      
+	 --------        | | | |           :         
+	 --------        | | | |           :         
+
+   Assumptions:
+   - B is row-stored;
+   - A is row- or column-stored;
+   - m0 and n0 are at most MR and NR, respectively.
+   Therefore, this (r)ow-preferential kernel is well-suited for contiguous
+   (v)ector loads on B and single-element broadcasts from A.
+
+   NOTE: These kernels explicitly support column-oriented IO, implemented
+   via an in-register transpose. And thus they also support the crr and
+   ccr cases, though only crr is ever utilized (because ccr is handled by
+   transposing the operation and executing rcr, which does not incur the
+   cost of the in-register transpose).
+
+   crr:
+	 | | | | | | | |       ------        --------      
+	 | | | | | | | |       ------        --------      
+	 | | | | | | | |  +=   ------ ...    --------      
+	 | | | | | | | |       ------        --------      
+	 | | | | | | | |       ------            :         
+	 | | | | | | | |       ------            :         
+*/
+
+// Prototype reference microkernels.
+//GEMMSUP_KER_PROT( float,   f, semmsup_r_zen_ref )
+
+void bli_sgemmsup_rv_zen_asm_6x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	uint64_t m_left = m0 % 6;
+	if ( m_left )
+	{
+		float* restrict cij = (float *)c;
+		float* restrict bj  = (float *)b;
+		float* restrict ai  = (float *)a;
+		
+		// We add special handling for slightly inflated MR blocksizes
+		// at edge cases, up to a maximum of 9.
+		if ( 6 < m0 )
+		{
+			gemmsup_ker_ft ker_fp1 = NULL;
+			gemmsup_ker_ft ker_fp2 = NULL;
+			dim_t           mr1, mr2;
+
+			if ( m0 == 7 )
+			{
+				mr1 = 4; mr2 = 3;
+				ker_fp1 = bli_sgemmsup_rv_zen_asm_4x16n;
+				ker_fp2 = bli_sgemmsup_rv_zen_asm_3x16n;
+			}
+			else if ( m0 == 8 )
+			{
+				mr1 = 4; mr2 = 4;
+				ker_fp1 = bli_sgemmsup_rv_zen_asm_4x16n;
+				ker_fp2 = bli_sgemmsup_rv_zen_asm_4x16n;
+			}
+			else // if ( m0 == 9 )
+			{
+				mr1 = 4; mr2 = 5;
+				ker_fp1 = bli_sgemmsup_rv_zen_asm_4x16n;
+				ker_fp2 = bli_sgemmsup_rv_zen_asm_5x16n;
+			}
+
+			ker_fp1
+			(
+			  conja, conjb, mr1, n0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += mr1*rs_c0; ai += mr1*rs_a0;
+
+			ker_fp2
+			(
+			  conja, conjb, mr2, n0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+
+			return;
+		}		
+		
+		gemmsup_ker_ft ker_fps[6] = 
+		{
+			NULL,
+			bli_sgemmsup_rv_zen_asm_1x16n,
+			bli_sgemmsup_rv_zen_asm_2x16n,
+			bli_sgemmsup_rv_zen_asm_3x16n,
+			bli_sgemmsup_rv_zen_asm_4x16n,
+			bli_sgemmsup_rv_zen_asm_5x16n 
+		};	
+		gemmsup_ker_ft ker_fp = ker_fps[ m_left ];
+		ker_fp
+		(
+			conja, conjb, m_left, n0, k0,
+			alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			beta, cij, rs_c0, cs_c0, data, cntx
+		);
+		return;		
+	}
+
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+
+	begin_asm()
+	
+	//vzeroall()                         // zero all xmm/ymm registers.
+	
+	//mov(var(a), rax)                   // load address of a.
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+	
+	lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+	lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+	//mov(var(cs_b), r11)                // load cs_b
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+	//lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+	                                   // NOTE: We cannot pre-load elements of a or b
+	                                   // because it could eventually, in the last
+	                                   // unrolled iter or the cleanup loop, result
+	                                   // in reading beyond the bounds allocated mem
+	                                   // (the likely result: a segmentation fault).
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP6X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+	vxorps(ymm6,  ymm6,  ymm6)
+	vxorps(ymm7,  ymm7,  ymm7)
+	vxorps(ymm8,  ymm8,  ymm8)
+	vxorps(ymm9,  ymm9,  ymm9)
+	vxorps(ymm10, ymm10, ymm10)
+	vxorps(ymm11, ymm11, ymm11)
+	vxorps(ymm12, ymm12, ymm12)
+	vxorps(ymm13, ymm13, ymm13)
+	vxorps(ymm14, ymm14, ymm14)
+	vxorps(ymm15, ymm15, ymm15)
+
+	mov(var(a), rax)                   // load address of a.
+	//mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	lea(mem(r12, rdi, 2), rdx)         //
+	lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+	prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+	prefetch(0, mem(r12, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+	prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+	prefetch(0, mem(rdx, rdi, 1, 7*8)) // prefetch c + 4*rs_c
+	prefetch(0, mem(rdx, rdi, 2, 7*8)) // prefetch c + 5*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done pre-fetching c
+
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	
+	label(.SLOOPKITER)                 // MAIN LOOP
+	
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*4))        // pre-fetch line of next upanel of b
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	vbroadcastss(mem(rax, r15, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	vfmadd231ps(ymm0, ymm3, ymm14)
+	vfmadd231ps(ymm1, ymm3, ymm15)
+
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	vbroadcastss(mem(rax, r15, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	vfmadd231ps(ymm0, ymm3, ymm14)
+	vfmadd231ps(ymm1, ymm3, ymm15)
+	
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	vbroadcastss(mem(rax, r15, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	vfmadd231ps(ymm0, ymm3, ymm14)
+	vfmadd231ps(ymm1, ymm3, ymm15)
+
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	vbroadcastss(mem(rax, r15, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	vfmadd231ps(ymm0, ymm3, ymm14)
+	vfmadd231ps(ymm1, ymm3, ymm15)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+	
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	vbroadcastss(mem(rax, r15, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	vfmadd231ps(ymm0, ymm3, ymm14)
+	vfmadd231ps(ymm1, ymm3, ymm15)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+	
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	vmulps(ymm0, ymm6, ymm6)
+	vmulps(ymm0, ymm7, ymm7)
+	vmulps(ymm0, ymm8, ymm8)
+	vmulps(ymm0, ymm9, ymm9)
+	vmulps(ymm0, ymm10, ymm10)
+	vmulps(ymm0, ymm11, ymm11)
+	vmulps(ymm0, ymm12, ymm12)
+	vmulps(ymm0, ymm13, ymm13)
+	vmulps(ymm0, ymm14, ymm14)
+	vmulps(ymm0, ymm15, ymm15)
+	
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+	                                   // now avoid loading C if beta == 0
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+	cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+	jz(.SCOLSTORED)                    // jump to column storage case
+	
+	label(.SROWSTORED)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm6)
+	vmovups(ymm6, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm7)
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm8)
+	vmovups(ymm8, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm9)
+	vmovups(ymm9, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm10)
+	vmovups(ymm10, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm11)
+	vmovups(ymm11, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm12)
+	vmovups(ymm12, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm13)
+	vmovups(ymm13, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm14)
+	vmovups(ymm14, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm15)
+	vmovups(ymm15, mem(rcx, rsi,8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+	vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+	vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	/***bottom left tile - 2x8 is transposed to top right tile 8x2**********/	
+	vunpcklps(ymm14, ymm12, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm0)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+	vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma41..gamma51 )
+	lea(mem(rdx, rsi, 4), rax) // rax += 4*cs_c	
+	
+	vmovlpd(mem(rax), xmm1, xmm1)
+	vmovhpd(mem(rax, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm2)
+	vmovlpd(xmm2, mem(rax)) // store ( gamma44..gamma54 )
+	vmovhpd(xmm2, mem(rax, rsi, 1)) // store ( gamma45..gamma55 )
+	lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c
+	
+	vunpckhps(ymm14, ymm12, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm0)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+	vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma43..gamma53 )
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm2)
+	vmovlpd(xmm2, mem(rdx)) // store ( gamma46..gamma56 )
+	vmovhpd(xmm2, mem(rdx, rsi, 1)) // store ( gamma47..gamma57 )
+	
+	lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c	
+	
+	/***top right tile  4x8 is transposed to bottom left tile 8x4**********/	
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+		
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	//lea(mem(rcx, rsi, 8), rcx) // rcx += 8*cs_c
+	/*** bottom right 2x8 is transposed to bottom right tile 8x2*******/	
+	vunpcklps(ymm15, ymm13, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm0)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+	vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma41..gamma51 )
+	lea(mem(rdx, rsi, 4), rax) // rax += 4*cs_c	
+	
+	vmovlpd(mem(rax), xmm1, xmm1)
+	vmovhpd(mem(rax, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm2)
+	vmovlpd(xmm2, mem(rax)) // store ( gamma44..gamma54 )
+	vmovhpd(xmm2, mem(rax, rsi, 1)) // store ( gamma45..gamma55 )
+	lea(mem(rdx, rsi, 2), rdx) // rdx += 2*cs_c
+	
+	vunpckhps(ymm15, ymm13, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm0)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+	vmovhpd(xmm0, mem(rdx, rsi, 1)) // store ( gamma43..gamma53 )
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	vmovlpd(mem(rdx), xmm1, xmm1)
+	vmovhpd(mem(rdx, rsi, 1), xmm1, xmm1)
+	vfmadd231ps(xmm1, xmm3, xmm2)
+	vmovlpd(xmm2, mem(rdx)) // store ( gamma46..gamma56 )
+	vmovhpd(xmm2, mem(rdx, rsi, 1)) // store ( gamma47..gamma57 )
+
+	jmp(.SDONE)                        // jump to end.
+	
+	label(.SBETAZERO)
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+	
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi, 8))
+	add(rdi, rcx)
+
+	vmovups(ymm6, mem(rcx))
+	vmovups(ymm7, mem(rcx, rsi, 8))
+	add(rdi, rcx)
+	
+	vmovups(ymm8, mem(rcx))
+	vmovups(ymm9, mem(rcx, rsi, 8))
+	add(rdi, rcx)
+	
+	vmovups(ymm10, mem(rcx))
+	vmovups(ymm11, mem(rcx, rsi, 8))
+	add(rdi, rcx)
+	
+	vmovups(ymm12, mem(rcx))
+	vmovups(ymm13, mem(rcx, rsi, 8))
+	add(rdi, rcx)
+	
+	vmovups(ymm14, mem(rcx))
+	vmovups(ymm15, mem(rcx, rsi, 8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	/****6x16 tile going to save into 16x6 tile in C*****/	
+	/******************top left tile 8x4***************************/	
+	vunpcklps(ymm6, ymm4, ymm0)
+	vunpcklps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	/******************top right tile 8x2***************************/
+	vunpcklps(ymm14, ymm12, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+	vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+	lea(mem(rdx, rsi, 1), rdx)
+	vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )	
+	vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+	lea(mem(rdx, rsi, 1), rdx)
+	
+	vunpckhps(ymm14, ymm12, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+	vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )	
+	lea(mem(rdx, rsi, 1), rdx)
+	vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+	vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+	lea(mem(rdx, rsi, 1), rdx)
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 8*cs_c
+	
+	/******************bottom left tile 8x4***************************/
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c	
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += 1*cs_c
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	/******************bottom right tile 8x2***************************/
+	vunpcklps(ymm15, ymm13, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma40..gamma50 )
+	vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma44..gamma54 )
+	lea(mem(rdx, rsi, 1), rdx)
+	vmovhpd(xmm0, mem(rdx)) // store ( gamma41..gamma51 )	
+	vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma45..gamma55 )
+	lea(mem(rdx, rsi, 1), rdx)
+	
+	vunpckhps(ymm15, ymm13, ymm0)
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovlpd(xmm0, mem(rdx)) // store ( gamma42..gamma52 )
+	vmovlpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma46..gamma56 )	
+	lea(mem(rdx, rsi, 1), rdx)
+	vmovhpd(xmm0, mem(rdx)) // store ( gamma43..gamma53 )
+	vmovhpd(xmm2, mem(rdx, rsi, 4)) // store ( gamma47..gamma57 )
+
+	label(.SDONE)
+	
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP6X16J)                    // iterate again if jj != 0.
+
+	label(.SRETURN)
+
+    end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5", "ymm6", "ymm7",
+	  "ymm8", "ymm9", "ymm10", "ymm11",
+	  "ymm12", "ymm13", "ymm14", "ymm15",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+		const dim_t      mr_cur = 6;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+		
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+			bli_sgemmsup_rv_zen_asm_6x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_6x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_6x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}		
+	}
+}
+
+void bli_sgemmsup_rv_zen_asm_5x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+	begin_asm()
+
+	//mov(var(a), rax)                   // load address of a.
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+	
+	lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+	                                   // NOTE: We cannot pre-load elements of a or b
+	                                   // because it could eventually, in the last
+	                                   // unrolled iter or the cleanup loop, result
+	                                   // in reading beyond the bounds allocated mem
+	                                   // (the likely result: a segmentation fault).
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP6X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+	vxorps(ymm6,  ymm6,  ymm6)
+	vxorps(ymm7,  ymm7,  ymm7)
+	vxorps(ymm8,  ymm8,  ymm8)
+	vxorps(ymm9,  ymm9,  ymm9)
+	vxorps(ymm10, ymm10, ymm10)
+	vxorps(ymm11, ymm11, ymm11)
+	vxorps(ymm12, ymm12, ymm12)
+	vxorps(ymm13, ymm13, ymm13)
+
+	mov(var(a), rax)                   // load address of a.
+	//mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	lea(mem(r12, rdi, 2), rdx)         //
+	lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+	prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+	prefetch(0, mem(r12, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+	prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+	prefetch(0, mem(rdx, rdi, 1, 7*8)) // prefetch c + 4*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 4*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 4*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 4*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 4*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 4*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 4*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 4*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 4*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done prefetching c
+
+	lea(mem(r10, r10, 2), rcx)         // rcx = 3*rs_b;
+	//lea(mem(rbx, r10, 8), rdx)         // use rdx for prefetching b.
+	//lea(mem(rdx, r10, 8), rdx)         // rdx = b + 16*rs_b;
+
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	
+	label(.SLOOPKITER)                 // MAIN LOOP
+	
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*8))        // prefetch line of next upanel of b
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+	
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	vbroadcastss(mem(rax, r8,  4), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm12)
+	vfmadd231ps(ymm1, ymm2, ymm13)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+		
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	vmulps(ymm0, ymm6, ymm6)
+	vmulps(ymm0, ymm7, ymm7)
+	vmulps(ymm0, ymm8, ymm8)
+	vmulps(ymm0, ymm9, ymm9)
+	vmulps(ymm0, ymm10, ymm10)
+	vmulps(ymm0, ymm11, ymm11)
+	vmulps(ymm0, ymm12, ymm12)
+	vmulps(ymm0, ymm13, ymm13)
+	
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;	
+	
+	                                   // now avoid loading C if beta == 0
+	
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+	
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORED)                    // jump to column storage case
+		
+	label(.SROWSTORED)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm6)
+	vmovups(ymm6, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm7)
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm8)
+	vmovups(ymm8, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm9)
+	vmovups(ymm9, mem(rcx, rsi,8))
+	add(rdi, rcx)	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm10)
+	vmovups(ymm10, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm11)
+	vmovups(ymm11, mem(rcx, rsi,8))
+	add(rdi, rcx)	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm12)
+	vmovups(ymm12, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm13)
+	vmovups(ymm13, mem(rcx, rsi,8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+	vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+	vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	
+	/*********************************************/
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+		
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	//lea(mem(rcx, rsi, 8), rcx) // rcx += 8*cs_c
+	vextractf128(imm(0x0), ymm13, xmm0)//e0-e3
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0,xmm0, xmm1)
+	vshufps(imm(0x02), xmm0,xmm0, xmm2)
+	vshufps(imm(0x03), xmm0,xmm0, xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm13, xmm0)//e4-e7
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0,xmm0, xmm1)
+	vshufps(imm(0x02), xmm0,xmm0, xmm2)
+	vshufps(imm(0x03), xmm0,xmm0, xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	jmp(.SDONE)                        // jump to end.
+	
+	label(.SBETAZERO)
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+		
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vmovups(ymm6, mem(rcx))
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+		
+	vmovups(ymm8, mem(rcx))
+	vmovups(ymm9, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vmovups(ymm10, mem(rcx))
+	vmovups(ymm11, mem(rcx, rsi,8))
+	add(rdi, rcx)
+		
+	vmovups(ymm12, mem(rcx))
+	vmovups(ymm13, mem(rcx, rsi,8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+	vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+	vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm12, xmm0)//e0-e3
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm12, xmm0)//e4-e7
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	
+	/*********************************************/
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+		
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	vextractf128(imm(0x0), ymm13, xmm0)//e0-e3
+	vshufps(imm(0x01), xmm0,xmm0, xmm1)
+	vshufps(imm(0x02), xmm0,xmm0, xmm2)
+	vshufps(imm(0x03), xmm0,xmm0, xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm13, xmm0)//e4-e7
+	vshufps(imm(0x01), xmm0,xmm0, xmm1)
+	vshufps(imm(0x02), xmm0,xmm0, xmm2)
+	vshufps(imm(0x03), xmm0,xmm0, xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+	
+	label(.SDONE)
+
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+    lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP6X16J)                    // iterate again if jj != 0.
+
+	label(.SRETURN)
+	
+	end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),	  
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5", "ymm6", "ymm7",
+	  "ymm8", "ymm9", "ymm10", "ymm11",
+	  "ymm12", "ymm13",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+		const dim_t      mr_cur = 5;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+
+			bli_sgemmsup_rv_zen_asm_5x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_5x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_5x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}
+
+	}
+}
+
+void bli_sgemmsup_rv_zen_asm_4x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+
+	begin_asm()
+
+	//vzeroall()                         // zero all xmm/ymm registers.
+	
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+	
+	lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+	//lea(mem(r8, r8, 4), r15)           // r15 = 5*rs_a
+
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+	                                   // NOTE: We cannot pre-load elements of a or b
+	                                   // because it could eventually, in the last
+	                                   // unrolled iter or the cleanup loop, result
+	                                   // in reading beyond the bounds allocated mem
+	                                   // (the likely result: a segmentation fault).
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP4X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+	vxorps(ymm6,  ymm6,  ymm6)
+	vxorps(ymm7,  ymm7,  ymm7)
+	vxorps(ymm8,  ymm8,  ymm8)
+	vxorps(ymm9,  ymm9,  ymm9)
+	vxorps(ymm10, ymm10, ymm10)
+	vxorps(ymm11, ymm11, ymm11)
+
+	mov(var(a), rax)                   // load address of a.
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	lea(mem(r12, rdi, 2), rdx)         //
+	lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+	prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+	prefetch(0, mem(r12, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+	prefetch(0, mem(rdx, 7*8))         // prefetch c + 3*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 3*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 3*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 3*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 3*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 3*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 3*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 3*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 3*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done prefetching c
+
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	
+	label(.SLOOPKITER)                 // MAIN LOOP
+	
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*8))        // prefetch line of next upanel of b
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+			
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	vbroadcastss(mem(rax, r13, 1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	vfmadd231ps(ymm0, ymm3, ymm10)
+	vfmadd231ps(ymm1, ymm3, ymm11)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+		
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	vmulps(ymm0, ymm6, ymm6)
+	vmulps(ymm0, ymm7, ymm7)
+	vmulps(ymm0, ymm8, ymm8)
+	vmulps(ymm0, ymm9, ymm9)
+	vmulps(ymm0, ymm10, ymm10)
+	vmulps(ymm0, ymm11, ymm11)
+	
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+	                                   // now avoid loading C if beta == 0
+	
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+	cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+	jz(.SCOLSTORED)                    // jump to column storage case
+	
+	label(.SROWSTORED)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm6)
+	vmovups(ymm6, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm7)
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm8)
+	vmovups(ymm8, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm9)
+	vmovups(ymm9, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vfmadd231ps(mem(rcx), ymm3, ymm10)
+	vmovups(ymm10, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm11)
+	vmovups(ymm11, mem(rcx, rsi,8))
+	//add(rdi, rcx)
+		
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+	vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+	vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+		
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm0)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vfmadd231ps(mem(rcx), xmm3, xmm1)
+	vfmadd231ps(mem(rcx, rsi, 4), xmm3, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+
+	jmp(.SDONE)                        // jump to end.
+	
+	label(.SBETAZERO)
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+	
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+
+	vmovups(ymm6, mem(rcx))
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vmovups(ymm8, mem(rcx))
+	vmovups(ymm9, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vmovups(ymm10, mem(rcx))
+	vmovups(ymm11, mem(rcx, rsi,8))
+	//add(rdi, rcx)
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a4b4a5b5
+	vunpcklps(ymm10, ymm8, ymm1)    //c0d0c1d1 c4d4c5d5
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2) 
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0) 
+	vblendps(imm(0x33), ymm2, ymm1, ymm1) 
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vunpckhps(ymm6, ymm4, ymm0)
+	vunpckhps(ymm10, ymm8, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+	vunpcklps(ymm7, ymm5, ymm0)
+	vunpcklps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma00..gamma30 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma04..gamma34 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma01..gamma31 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma05..gamma35 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+		
+	vunpckhps(ymm7, ymm5, ymm0)
+	vunpckhps(ymm11, ymm9, ymm1)
+	vshufps(imm(0x4e), ymm1, ymm0, ymm2)
+	vblendps(imm(0xcc), ymm2, ymm0, ymm0)
+	vblendps(imm(0x33), ymm2, ymm1, ymm1)
+	
+	vextractf128(imm(0x1), ymm0, xmm2)
+	vmovups(xmm0, mem(rcx)) // store ( gamma02..gamma32 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma06..gamma36 )
+	lea(mem(rcx, rsi, 1), rcx) // rcx += cs_c
+	
+	vextractf128(imm(0x1), ymm1, xmm2)
+	vmovups(xmm1, mem(rcx)) // store ( gamma03..gamma33 )
+	vmovups(xmm2, mem(rcx, rsi, 4)) // store ( gamma07..gamma37 )
+	
+	label(.SDONE)
+
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP4X16J)                    // iterate again if jj != 0.
+
+	label(.SRETURN)
+	
+    end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),	  
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5", "ymm6", "ymm7",
+	  "ymm8", "ymm9", "ymm10", "ymm11",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+
+		const dim_t      mr_cur = 4;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+		
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+
+			bli_sgemmsup_rv_zen_asm_4x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_4x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_4x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}
+		
+	}
+}
+
+void bli_sgemmsup_rv_zen_asm_3x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+	begin_asm()
+
+	//mov(var(a), rax)                   // load address of a.
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+	
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+	
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+	
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP4X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+	vxorps(ymm6,  ymm6,  ymm6)
+	vxorps(ymm7,  ymm7,  ymm7)
+	vxorps(ymm8,  ymm8,  ymm8)
+	vxorps(ymm9,  ymm9,  ymm9)
+	vxorps(ymm10, ymm10, ymm10)
+	vxorps(ymm11, ymm11, ymm11)
+	vxorps(ymm12, ymm12, ymm12)
+	vxorps(ymm13, ymm13, ymm13)
+	vxorps(ymm14, ymm14, ymm14)
+	vxorps(ymm15, ymm15, ymm15)
+
+	mov(var(a), rax)                   // load address of a.
+
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+	prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+	prefetch(0, mem(r12, rdi, 2, 7*8)) // prefetch c + 2*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 2*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 2*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 2*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 2*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 2*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 2*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 2*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 2*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done prefetching c
+
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	label(.SLOOPKITER)                 // MAIN LOOP
+		
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*8))        // prefetch line of next upanel of b
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+		
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+		
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	vbroadcastss(mem(rax, r8,  2), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm8)
+	vfmadd231ps(ymm1, ymm2, ymm9)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+		
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	vmulps(ymm0, ymm6, ymm6)
+	vmulps(ymm0, ymm7, ymm7)
+	vmulps(ymm0, ymm8, ymm8)
+	vmulps(ymm0, ymm9, ymm9)
+		
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rcx, rdi, 2), rdx)         // load address of c +  2*rs_c;
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+		                                   // now avoid loading C if beta == 0
+	
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+	cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+	jz(.SCOLSTORED)                    // jump to column storage case
+	
+	label(.SROWSTORED)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm6)
+	vmovups(ymm6, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm7)
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm8)
+	vmovups(ymm8, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm9)
+	vmovups(ymm9, mem(rcx, rsi,8))
+		
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm0)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm2)
+	vfmadd231ps(xmm6, xmm3, xmm10)	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3		
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm11)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm12)
+	vfmadd231ps(xmm6, xmm3, xmm10)
+	vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm11)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm11, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm8, xmm0)//e4-e7
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e4
+	vfmadd231ps(xmm6, xmm3, xmm1)//e5
+	vfmadd231ps(xmm8, xmm3, xmm2)//e6
+	vfmadd231ps(xmm10, xmm3, xmm14)//e7
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	
+	/*********************************************/
+	vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm0)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm2)
+	vfmadd231ps(xmm6, xmm3, xmm10)	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3		
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm11)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm12)
+	vfmadd231ps(xmm6, xmm3, xmm10)
+	vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm9, xmm0)//c0-c3
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm9, xmm0)//e4-e7
+	vmovss(mem(rdx),xmm4)
+	vmovss(mem(rdx, rsi, 1),xmm6)
+	vmovss(mem(rdx, rsi, 2),xmm8)
+	vmovss(mem(rdx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm8, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+		
+	jmp(.SDONE)                        // jump to end.
+		
+	label(.SBETAZERO)
+	
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+		
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+
+	vmovups(ymm6, mem(rcx))
+	vmovups(ymm7, mem(rcx, rsi,8))
+	add(rdi, rcx)
+	
+	vmovups(ymm8, mem(rcx))
+	vmovups(ymm9, mem(rcx, rsi,8))
+	//add(rdi, rcx)
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7	
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm8, xmm0)//c0-c3
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm8, xmm0)//c4-c7
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+	
+	/*********************************************/
+	vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7	
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	
+	/********************************************/
+	vextractf128(imm(0x0), ymm9, xmm0)//c0-c3
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	lea(mem(rdx, rsi, 4), rdx) // rdx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm9, xmm0)//c4-c7
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rdx))
+	vmovss(xmm1, mem(rdx, rsi, 1))
+	vmovss(xmm2, mem(rdx, rsi, 2))
+	vmovss(xmm14, mem(rdx, rax, 1))
+
+	label(.SDONE)
+
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+	lea(mem(r12, rsi, 8), r12)
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP4X16J)                    // iterate again if jj != 0.
+
+	label(.SRETURN)
+
+    end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),	  
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5", "ymm6", "ymm7",
+	  "ymm8", "ymm9", "ymm10", "ymm11",
+	  "ymm12", "ymm13", "ymm14", "ymm15",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+		const dim_t      mr_cur = 3;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+
+			bli_sgemmsup_rv_zen_asm_3x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_3x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_3x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}
+	
+	}
+}
+
+void bli_sgemmsup_rv_zen_asm_2x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+	begin_asm()
+
+	//mov(var(a), rax)                   // load address of a.
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+	
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+	//mov(var(cs_b), r11)                // load cs_b
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+	//lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+	                                   // NOTE: We cannot pre-load elements of a or b
+	                                   // because it could eventually, in the last
+	                                   // unrolled iter or the cleanup loop, result
+	                                   // in reading beyond the bounds allocated mem
+	                                   // (the likely result: a segmentation fault).
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP2X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+	vxorps(ymm6,  ymm6,  ymm6)
+	vxorps(ymm7,  ymm7,  ymm7)
+
+	mov(var(a), rax)                   // load address of a.
+	//mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+	prefetch(0, mem(r12, rdi, 1, 7*8)) // prefetch c + 1*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 1*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 1*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 1*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 1*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 1*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 1*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 1*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done prefetching c
+
+
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	
+	
+	label(.SLOOPKITER)                 // MAIN LOOP
+		
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*8))        // prefetch line of next upanel of b
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+		
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+	
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	vbroadcastss(mem(rax, r8,  1), ymm3)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	vfmadd231ps(ymm0, ymm3, ymm6)
+	vfmadd231ps(ymm1, ymm3, ymm7)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+		
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	vmulps(ymm0, ymm6, ymm6)
+	vmulps(ymm0, ymm7, ymm7)
+	
+	
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+	                                   // now avoid loading C if beta == 0
+	
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORED)                    // jump to column storage case
+		
+	label(.SROWSTORED)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm6)
+	vmovups(ymm6, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm7)
+	vmovups(ymm7, mem(rcx, rsi,8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm0)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm2)
+	vfmadd231ps(xmm6, xmm3, xmm10)	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3		
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm11)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm12)
+	vfmadd231ps(xmm6, xmm3, xmm10)
+	vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+	vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm11)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm12)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm0)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm2)
+	vfmadd231ps(xmm6, xmm3, xmm10)	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vshufpd(imm(0x01), xmm11, xmm11, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm12, xmm12, xmm10)//a3b3		
+	vmovsd(mem(rcx),xmm4)
+	vmovsd(mem(rcx, rsi, 1),xmm6)	
+	vfmadd231ps(xmm4, xmm3, xmm11)
+	vfmadd231ps(xmm6, xmm3, xmm1)
+	vmovsd(xmm11, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(mem(rcx, rsi, 2),xmm4)
+	vmovsd(mem(rcx, rax, 1),xmm6)
+	vfmadd231ps(xmm4, xmm3, xmm12)
+	vfmadd231ps(xmm6, xmm3, xmm10)
+	vmovsd(xmm12, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+		
+	jmp(.SDONE)                        // jump to end.
+	
+	label(.SBETAZERO)
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+	
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi,8))
+	add(rdi, rcx)
+
+	vmovups(ymm6, mem(rcx))
+	vmovups(ymm7, mem(rcx, rsi,8))
+	
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	vunpcklps(ymm6, ymm4, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm6, ymm4, ymm2)    //a2b2a3b3 a6b6a7b7	
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+	vunpcklps(ymm7, ymm5, ymm0)    //a0b0a1b1 a2b2a3b3
+	vunpckhps(ymm7, ymm5, ymm2)    //a2b2a3b3 a6b6a7b7	
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a1b1
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3	
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	
+	vperm2f128(imm(0x01),ymm0,ymm0,ymm0)
+	vperm2f128(imm(0x01),ymm2,ymm2,ymm2)
+	vshufpd(imm(0x01), xmm0, xmm0, xmm1)//a2b2
+	vshufpd(imm(0x01), xmm2, xmm2, xmm10)//a3b3
+	vmovsd(xmm0, mem(rcx)) // store ( gamma00..gamma10 )
+	vmovsd(xmm1, mem(rcx, rsi, 1)) // store ( gamma01..gamma11 )	
+	vmovsd(xmm2, mem(rcx, rsi, 2)) // store ( gamma02..gamma12 )
+	vmovsd(xmm10, mem(rcx, rax, 1)) // store ( gamma03..gamma13 )	
+	
+	label(.SDONE)
+
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+	lea(mem(r12, rsi, 8), r12)
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP2X16J)                    // iterate again if jj != 0.
+
+	label(.SRETURN)
+
+    end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),	  
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5", "ymm6", "ymm7",
+	  "ymm11", "ymm12",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+		const dim_t      mr_cur = 2;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+
+			bli_sgemmsup_rv_zen_asm_2x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_2x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_2x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}
+	}
+}
+
+void bli_sgemmsup_rv_zen_asm_1x16n
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+	//void*    a_next = bli_auxinfo_next_a( data );
+	//void*    b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+
+	uint64_t n_iter = n0 /16;
+	uint64_t n_left = n0 % 16;
+
+	uint64_t rs_a   = rs_a0;
+	uint64_t cs_a   = cs_a0;
+	uint64_t rs_b   = rs_b0;
+	uint64_t cs_b   = cs_b0;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+	// Query the panel stride of B and convert it to units of bytes.
+	uint64_t ps_b   = bli_auxinfo_ps_b( data );
+	uint64_t ps_b4  = ps_b * sizeof( float );
+
+	if ( n_iter == 0 ) goto consider_edge_cases;
+
+	// -------------------------------------------------------------------------
+	begin_asm()
+
+	//mov(var(a), rax)                   // load address of a.
+	mov(var(rs_a), r8)                 // load rs_a
+	mov(var(cs_a), r9)                 // load cs_a
+	lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+	lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+	mov(var(b), r14)                   // load address of b.
+	mov(var(rs_b), r10)                // load rs_b
+	//mov(var(cs_b), r11)                // load cs_b
+	lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+	//lea(mem(, r11, 4), r11)            // cs_b *= sizeof(float)
+
+	                                   // NOTE: We cannot pre-load elements of a or b
+	                                   // because it could eventually, in the last
+	                                   // unrolled iter or the cleanup loop, result
+	                                   // in reading beyond the bounds allocated mem
+	                                   // (the likely result: a segmentation fault).
+
+	mov(var(c), r12)                   // load address of c
+	mov(var(rs_c), rdi)                // load rs_c
+	lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+	// During preamble and loops:
+	// r12 = rcx = c
+	// r14 = rbx = b
+	// read rax from var(a) near beginning of loop
+	// r11 = m dim index ii
+	mov(var(n_iter), r11)              // jj = n_iter;
+
+	label(.SLOOP1X16J)                  // LOOP OVER jj = [ n_iter ... 1 0 ]
+
+	vxorps(ymm4,  ymm4,  ymm4)
+	vxorps(ymm5,  ymm5,  ymm5)
+
+	mov(var(a), rax)                   // load address of a.
+	//mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(r14, rbx)                      // reset rbx to current upanel of b.
+
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLPFETCH)                    // jump to column storage case
+	label(.SROWPFETCH)                 // row-stored prefetching on c
+
+	prefetch(0, mem(r12, 7*8))         // prefetch c + 0*rs_c
+
+	jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+	label(.SCOLPFETCH)                 // column-stored prefetching c
+
+	mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+	lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+	lea(mem(r12, rsi, 2), rdx)         //
+	lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+	prefetch(0, mem(r12, 0*8))         // prefetch c + 0*cs_c
+	prefetch(0, mem(r12, rsi, 1, 0*8)) // prefetch c + 1*cs_c
+	prefetch(0, mem(r12, rsi, 2, 0*8)) // prefetch c + 2*cs_c
+	prefetch(0, mem(rdx, 1*8))         // prefetch c + 3*cs_c
+	prefetch(0, mem(rdx, rsi, 1, 0*8)) // prefetch c + 4*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 0*8)) // prefetch c + 5*cs_c
+	lea(mem(rdx, rsi, 2), rdx)         // rdx = c + 5*cs_c;
+	prefetch(0, mem(rdx, rsi, 1, 0*8)) // prefetch c + 6*cs_c
+	prefetch(0, mem(rdx, rsi, 2, 0*8)) // prefetch c + 7*cs_c
+
+	label(.SPOSTPFETCH)                // done prefetching c
+	
+	mov(var(k_iter), rsi)              // i = k_iter;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+	                                   // contains the k_left loop.
+	
+	label(.SLOOPKITER)                 // MAIN LOOP
+	
+	// ---------------------------------- iteration 0
+	prefetch(0, mem(rbx, 11*8))        // prefetch line of next upanel of b
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	
+	// ---------------------------------- iteration 1
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	
+	// ---------------------------------- iteration 2
+	prefetch(0, mem(rbx, 11*8))
+	
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	
+	// ---------------------------------- iteration 3
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx, 0*32), ymm0)
+	vmovups(mem(rbx, 1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+
+	vbroadcastss(mem(rax        ), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKITER)                   // iterate again if i != 0.
+		
+	label(.SCONSIDKLEFT)
+	
+	mov(var(k_left), rsi)              // i = k_left;
+	test(rsi, rsi)                     // check i via logical AND.
+	je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+	                                   // else, we prepare to enter k_left loop.
+	
+	label(.SLOOPKLEFT)                 // EDGE LOOP
+
+	prefetch(0, mem(rbx, 11*8))
+
+	vmovups(mem(rbx,  0*32), ymm0)
+	vmovups(mem(rbx,  1*32), ymm1)
+	add(r10, rbx)                      // b += rs_b;
+	
+	vbroadcastss(mem(rax        ), ymm2)
+	add(r9, rax)                       // a += cs_a;
+	vfmadd231ps(ymm0, ymm2, ymm4)
+	vfmadd231ps(ymm1, ymm2, ymm5)
+	
+	
+	dec(rsi)                           // i -= 1;
+	jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+	
+	label(.SPOSTACCUM)
+	
+	mov(r12, rcx)                      // reset rcx to current utile of c.
+	mov(var(alpha), rax)               // load address of alpha
+	mov(var(beta), rbx)                // load address of beta
+	vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+	vbroadcastss(mem(rbx), ymm3)       // load beta and duplicate
+	
+	vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+	vmulps(ymm0, ymm5, ymm5)
+	
+	mov(var(cs_c), rsi)                // load cs_c
+	lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+	
+	lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+	                                   // now avoid loading C if beta == 0
+	
+	vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+	vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+	je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+	cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+	jz(.SCOLSTORED)                    // jump to column storage case
+	
+	label(.SROWSTORED)
+		
+	vfmadd231ps(mem(rcx), ymm3, ymm4)
+	vmovups(ymm4, mem(rcx))
+
+	vfmadd231ps(mem(rcx, rsi,8), ymm3, ymm5)
+	vmovups(ymm5, mem(rcx, rsi,8))
+
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORED)
+
+	vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+	vmovss(mem(rcx),xmm7)
+	vmovss(mem(rcx, rsi, 1),xmm6)
+	vmovss(mem(rcx, rsi, 2),xmm11)
+	vmovss(mem(rcx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm7, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm11, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+	vextractf128(imm(0x1), ymm4, xmm0)//e4-e7
+	vmovss(mem(rcx),xmm4)
+	vmovss(mem(rcx, rsi, 1),xmm6)
+	vmovss(mem(rcx, rsi, 2),xmm8)
+	vmovss(mem(rcx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e4
+	vfmadd231ps(xmm6, xmm3, xmm1)//e5
+	vfmadd231ps(xmm8, xmm3, xmm2)//e6
+	vfmadd231ps(xmm10, xmm3, xmm14)//e7
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+	
+	vextractf128(imm(0x0), ymm5, xmm0)//c0-c3
+	vmovss(mem(rcx),xmm4)
+	vmovss(mem(rcx, rsi, 1),xmm6)
+	vmovss(mem(rcx, rsi, 2),xmm11)
+	vmovss(mem(rcx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e0
+	vfmadd231ps(xmm6, xmm3, xmm1)//e1
+	vfmadd231ps(xmm11, xmm3, xmm2)//e2
+	vfmadd231ps(xmm10, xmm3, xmm14)//e3
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	lea(mem(rcx, rsi, 4), rcx) // rcx += 4*cs_c
+
+	vextractf128(imm(0x1), ymm5, xmm0)//e4-e7
+	vmovss(mem(rcx),xmm4)
+	vmovss(mem(rcx, rsi, 1),xmm6)
+	vmovss(mem(rcx, rsi, 2),xmm8)
+	vmovss(mem(rcx, rax, 1),xmm10)
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vfmadd231ps(xmm4, xmm3, xmm0)//e4
+	vfmadd231ps(xmm6, xmm3, xmm1)//e5
+	vfmadd231ps(xmm8, xmm3, xmm2)//e6
+	vfmadd231ps(xmm10, xmm3, xmm14)//e7
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	
+	jmp(.SDONE)                        // jump to end.
+	
+	label(.SBETAZERO)
+	
+	cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+	jz(.SCOLSTORBZ)                    // jump to column storage case
+	
+	label(.SROWSTORBZ)
+		
+	vmovups(ymm4, mem(rcx))
+	vmovups(ymm5, mem(rcx, rsi,8))
+
+	jmp(.SDONE)                        // jump to end.
+
+	label(.SCOLSTORBZ)
+
+	vextractf128(imm(0x0), ymm4, xmm0)//c0-c3
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+
+	vextractf128(imm(0x1), ymm4, xmm0)//e4-e7
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+
+	vextractf128(imm(0x0), ymm5, xmm0)//c0-c3
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+	lea(mem(rcx, rsi, 4), rcx) // rcx += cs_c
+
+	vextractf128(imm(0x1), ymm5, xmm0)//e4-e7
+	vshufps(imm(0x01), xmm0, xmm0,xmm1)
+	vshufps(imm(0x02), xmm0, xmm0,xmm2)
+	vshufps(imm(0x03), xmm0, xmm0,xmm14)
+	vmovss(xmm0, mem(rcx))
+	vmovss(xmm1, mem(rcx, rsi, 1))
+	vmovss(xmm2, mem(rcx, rsi, 2))
+	vmovss(xmm14, mem(rcx, rax, 1))
+
+	label(.SDONE)
+
+	lea(mem(r12, rsi, 8), r12)         // c_jj = r12 += 8*cs_c
+        lea(mem(r12, rsi, 8), r12)
+	//add(imm(4*16), r14)                 // b_jj = r14 += 8*cs_b
+	mov(var(ps_b4), rbx)               // load ps_b4
+	lea(mem(r14, rbx, 1), r14)         // a_ii = r14 += ps_b4
+
+	dec(r11)                           // jj -= 1;
+	jne(.SLOOP1X16J)                    // iterate again if jj != 0.
+	label(.SRETURN)
+	
+    end_asm(
+	: // output operands (none)
+	: // input operands
+      [n_iter] "m" (n_iter),
+      [k_iter] "m" (k_iter),
+      [k_left] "m" (k_left),
+      [a]      "m" (a),
+      [rs_a]   "m" (rs_a),
+      [cs_a]   "m" (cs_a),
+      [b]      "m" (b),
+      [rs_b]   "m" (rs_b),
+      [cs_b]   "m" (cs_b),
+	  [ps_b4]  "m" (ps_b4),	  
+      [alpha]  "m" (alpha),
+      [beta]   "m" (beta),
+      [c]      "m" (c),
+      [rs_c]   "m" (rs_c),
+      [cs_c]   "m" (cs_c)/*,
+      [a_next] "m" (a_next),
+      [b_next] "m" (b_next)*/
+	: // register clobber list
+	  "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+	  "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+	  "xmm0", "xmm1", "xmm2", "xmm3",
+	  "xmm4", "xmm5", "xmm6", "xmm7",
+	  "xmm8", "xmm9", "xmm10", "xmm11",
+	  "xmm12", "xmm13", "xmm14", "xmm15",
+	  "ymm0", "ymm1", "ymm2", "ymm3",
+	  "ymm4", "ymm5",
+	  "memory"
+	)
+
+	consider_edge_cases:
+
+	// Handle edge cases in the m dimension, if they exist.
+	if ( n_left )
+	{
+		const dim_t      mr_cur = 1;
+		const dim_t      j_edge = n0 - ( dim_t )n_left;
+
+		float* restrict cij = (float *)c + j_edge*cs_c;
+		float* restrict ai  = (float *)a;
+		float* restrict bj  = (float *)b + n_iter * ps_b;
+
+		if ( 8 <= n_left )
+		{
+			const dim_t nr_cur = 8;
+
+			bli_sgemmsup_rv_zen_asm_1x8
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		
+		if ( 4 <= n_left )
+		{
+			const dim_t nr_cur = 4;
+
+			bli_sgemmsup_rv_zen_asm_1x4
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 2 <= n_left )
+		{
+			const dim_t nr_cur = 2;
+
+			bli_sgemmsup_rv_zen_asm_1x2
+			(
+			  conja, conjb, mr_cur, nr_cur, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0, cs_b0,
+			  beta, cij, rs_c0, cs_c0, data, cntx
+			);
+			cij += nr_cur*cs_c0; bj += nr_cur*cs_b0; n_left -= nr_cur;
+		}
+		if ( 1 == n_left )
+		{
+			bli_sgemv_ex
+			(
+			  BLIS_NO_TRANSPOSE, conjb, m0, k0,
+			  alpha, ai, rs_a0, cs_a0, bj, rs_b0,
+			  beta, cij, rs_c0, cntx, NULL
+			);
+		}
+	
+	}
+}
+

--- a/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x16_mask.c
+++ b/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x16_mask.c
@@ -1,0 +1,1785 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2023 - 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+static const int32_t mask[8][8] = { {0, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, -1, 0},
+                                  };
+
+void bli_sgemmsup_rv_zen_asm_5x16_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)       //load
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,        8*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,8*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,8*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,        8*4)) // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1,8*4)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    vfmadd231ps(ymm1, ymm2, ymm13)
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm1)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+    vmulps(ymm0, ymm12, ymm12)
+    vmulps(ymm0, ymm13, ymm13)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm1)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm6)
+    vmovups(ymm6, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm7)
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm8)
+    vmovups(ymm8, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm9)
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm10)
+    vmovups(ymm10, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm11)
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm1, ymm12)
+    vmovups(ymm12, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm1, ymm13)
+    vmaskmovps(ymm13, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx, 0*32))
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx, 0*32))
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm10, mem(rcx, 0*32))
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm12, mem(rcx, 0*32))
+    vmaskmovps(ymm13, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r13", "r14",
+      "xmm0", "xmm1",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6",
+      "ymm7", "ymm8", "ymm9", "ymm10", "ymm11", "ymm12", "ymm13",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x16_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)       //load
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,        8*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,8*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,8*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,        8*4)) // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+
+    // ---------------------------------- iteration 0
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    add(r9, rax)                       // a += cs_a;
+
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    add(r9, rax)                       // a += cs_a;
+
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+    vfmadd231ps(ymm1, ymm2, ymm11)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm12)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm11, ymm11)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm12)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm6)
+    vmovups(ymm6, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm7)
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm8)
+    vmovups(ymm8, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm9)
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm10)
+    vmovups(ymm10, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm11)
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx, 0*32))
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx, 0*32))
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm10, mem(rcx, 0*32))
+    vmaskmovps(ymm11, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r13", "r14",
+      "xmm0", "xmm12",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6",
+      "ymm7", "ymm8", "ymm9", "ymm10", "ymm11", "ymm12",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x16_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)            //load mask values
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12,        8*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,8*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,8*4)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vfmadd231ps(ymm1, ymm2, ymm9)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm12)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm9, ymm9)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm12)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm6)
+    vmovups(ymm6, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm7)
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm8)
+    vmovups(ymm8, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm9)
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx, 0*32))
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+    add(rdi, rcx)
+
+    vmovups(ymm8, mem(rcx, 0*32))
+    vmaskmovps(ymm9, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0", "xmm12",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6",
+      "ymm7", "ymm8", "ymm9", "ymm12",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x16_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)       //load
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12,        8*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,8*4)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+    vfmadd231ps(ymm1, ymm2, ymm7)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm14)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm7, ymm7)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm14)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm14, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm14, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm14, ymm6)
+    vmovups(ymm6, mem(rcx, 0*32))
+
+    vmaskmovps(mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm14, ymm7)
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    add(rdi, rcx)
+
+    vmovups(ymm6, mem(rcx, 0*32))
+    vmaskmovps(ymm7, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0", "xmm14",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6",
+      "ymm7", "ymm14",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x16_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)           //load mask values
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12,        8*4)) // prefetch c + 0*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 7*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 8*cs_c
+    lea(mem(r12, rsi, 8), rdx)         // rdx = c + 8*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 9*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 10*cs_c
+    prefetch(0, mem(rdx, rcx, 1, 5*4)) // prefetch c + 11*cs_c
+    prefetch(0, mem(rdx, rsi, 4, 5*4)) // prefetch c + 12*cs_c
+    lea(mem(r12, rcx, 4), rdx)         // rdx = c + 12*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 13*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 14*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmovups(mem(rbx, 0*32), ymm0)
+    vmaskmovps(mem(rbx, 1*32), ymm3, ymm1)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vfmadd231ps(ymm1, ymm2, ymm5)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm12)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm5, ymm5)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm12)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vfmadd231ps(mem(rcx, 0*32), ymm12, ymm4)
+    vmovups(ymm4, mem(rcx, 0*32))
+
+    vmaskmovps( mem(rcx, 1*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm12, ymm5)
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmovups(ymm4, mem(rcx, 0*32))
+    vmaskmovps(ymm5, ymm3, mem(rcx, 1*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0","xmm12",
+      "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm12",
+      "memory"
+    )
+}

--- a/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x4_mask.c
+++ b/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x4_mask.c
@@ -1,0 +1,1568 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2023 - 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+static const int32_t mask[8][8] = { {0, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, -1, 0},
+                                  };
+
+void bli_sgemmsup_rv_zen_asm_5x4_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    const int32_t *mask_vec = mask[n0];
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+    vxorps(xmm10, xmm10, xmm10)
+    vxorps(xmm12, xmm12, xmm12)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 0)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 0)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 0))         // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1, 0)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    vbroadcastss(mem(rax, r8,  4), xmm2)
+    add(r9, rax)                       // a += cs_a;
+    vfmadd231ps(xmm0, xmm2, xmm12)
+
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+    vmulps(xmm0, xmm12, xmm12)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm10)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm12)
+    vmaskmovps(xmm12, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm12, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]   "m"   (m_iter),
+      [k_iter]   "m"   (k_iter),
+      [k_left]   "m"   (k_left),
+      [a]        "m"   (a),
+      [rs_a]     "m"   (rs_a),
+      [cs_a]     "m"   (cs_a),
+      [ps_a4]    "m"   (ps_a4),
+      [b]        "m"   (b),
+      [rs_b]     "m"   (rs_b),
+      [cs_b]     "m"   (cs_b),
+      [alpha]    "m"   (alpha),
+      [beta]     "m"   (beta),
+      [c]        "m"   (c),
+      [rs_c]     "m"   (rs_c),
+      [cs_c]     "m"   (cs_c),
+      [mask_vec] "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm6", "xmm7",
+      "xmm8", "xmm10", "xmm12",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x4_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    const int32_t *mask_vec = mask[n0];
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+    vxorps(xmm10, xmm10, xmm10)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 0)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 0)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx, 0))         // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vbroadcastss(mem(rax, r13, 1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+    vfmadd231ps(xmm0, xmm3, xmm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+    vmulps(xmm0, xmm10, xmm10)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm10)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm10, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]   "m"  (m_iter),
+      [k_iter]   "m"  (k_iter),
+      [k_left]   "m"  (k_left),
+      [a]        "m"  (a),
+      [rs_a]     "m"  (rs_a),
+      [cs_a]     "m"  (cs_a),
+      [ps_a4]    "m"  (ps_a4),
+      [b]        "m"  (b),
+      [rs_b]     "m"  (rs_b),
+      [cs_b]     "m"  (cs_b),
+      [alpha]    "m"  (alpha),
+      [beta]     "m"  (beta),
+      [c]        "m"  (c),
+      [rs_c]     "m"  (rs_c),
+      [cs_c]     "m"  (cs_c),
+      [mask_vec] "m"  (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm6", "xmm7",
+      "xmm8", "xmm10",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x4_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    const int32_t *mask_vec = mask[n0];
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+    vxorps(xmm8,  xmm8,  xmm8)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 0)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2, 0)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    vbroadcastss(mem(rax, r8,  2), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+    vmulps(xmm0, xmm8, xmm8)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm8)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm8, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]   "m"   (m_iter),
+      [k_iter]   "m"   (k_iter),
+      [k_left]   "m"   (k_left),
+      [a]        "m"   (a),
+      [rs_a]     "m"   (rs_a),
+      [cs_a]     "m"   (cs_a),
+      [ps_a4]    "m"   (ps_a4),
+      [b]        "m"   (b),
+      [rs_b]     "m"   (rs_b),
+      [cs_b]     "m"   (cs_b),
+      [alpha]    "m"   (alpha),
+      [beta]     "m"   (beta),
+      [c]        "m"   (c),
+      [rs_c]     "m"   (rs_c),
+      [cs_c]     "m"   (cs_c),
+      [mask_vec] "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r14",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm6", "xmm7",
+      "xmm8", "xmm10",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x4_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    const int32_t *mask_vec = mask[n0];
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    vxorps(xmm1,  xmm1,  xmm1)
+    vxorps(xmm4,  xmm4,  xmm4)
+    vxorps(xmm6,  xmm6,  xmm6)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1, 0)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vbroadcastss(mem(rax, r8,  1), xmm3)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+    vfmadd231ps(xmm0, xmm3, xmm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+    vmulps(xmm0, xmm6, xmm6)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx), xmm7, xmm1)
+    vfmadd231ps(xmm1, xmm3, xmm6)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+    add(rdi, rcx)
+    vmaskmovps(xmm6, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]   "m"   (m_iter),
+      [k_iter]   "m"   (k_iter),
+      [k_left]   "m"   (k_left),
+      [a]        "m"   (a),
+      [rs_a]     "m"   (rs_a),
+      [cs_a]     "m"   (cs_a),
+      [ps_a4]    "m"   (ps_a4),
+      [b]        "m"   (b),
+      [rs_b]     "m"   (rs_b),
+      [cs_b]     "m"   (cs_b),
+      [alpha]    "m"   (alpha),
+      [beta]     "m"   (beta),
+      [c]        "m"   (c),
+      [rs_c]     "m"   (rs_c),
+      [cs_c]     "m"   (cs_c),
+      [mask_vec] "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r14",
+      "xmm0", "xmm1", "xmm2", "xmm3",
+      "xmm4", "xmm6", "xmm7",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x4_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    //void*    a_next = bli_auxinfo_next_a( data );
+    //void*    b_next = bli_auxinfo_next_b( data );
+
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t m_iter = m0 / 6;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    const int32_t *mask_vec = mask[n0];
+
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), xmm7)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+    vxorps(xmm4,  xmm4,  xmm4)
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12, 0))         // prefetch c + 0*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(r12, rsi, 2), rdx)         //
+    lea(mem(rdx, rsi, 1), rdx)         // rdx = c + 3*cs_c;
+    prefetch(0, mem(r12, 5*8))         // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*8)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*8)) // prefetch c + 2*cs_c
+    prefetch(0, mem(rdx, 5*8))         // prefetch c + 3*cs_c
+    prefetch(0, mem(rdx, rsi, 1, 5*8)) // prefetch c + 4*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*8)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+    lea(mem(rax, r8,  4), rdx)         // use rdx for prefetching lines
+    lea(mem(rdx, r8,  2), rdx)         // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    prefetch(0, mem(rdx, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    prefetch(0, mem(rdx, r9, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    prefetch(0, mem(rdx, r9, 2, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    prefetch(0, mem(rdx, rcx, 1, 5*8))
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // else, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    vmaskmovps(mem(rbx), xmm7, xmm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), xmm2)
+    vfmadd231ps(xmm0, xmm2, xmm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), xmm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), xmm3)       // load beta and duplicate
+
+    vmulps(xmm0, xmm4, xmm4)           // scale by alpha
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(xmm0, xmm0, xmm0)           // set xmm0 to zero.
+    vucomiss(xmm0, xmm3)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORED)                    // jump to column storage case
+
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx), xmm7, xmm0)
+    vfmadd231ps(xmm0, xmm3, xmm4)
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (8*rs_c) == 8.
+    jz(.SCOLSTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(xmm4, xmm7, mem(rcx))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOLSTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [m_iter]   "m"  (m_iter),
+      [k_iter]   "m"  (k_iter),
+      [k_left]   "m"  (k_left),
+      [a]        "m"  (a),
+      [rs_a]     "m"  (rs_a),
+      [cs_a]     "m"  (cs_a),
+      [ps_a4]    "m"  (ps_a4),
+      [b]        "m"  (b),
+      [rs_b]     "m"  (rs_b),
+      [cs_b]     "m"  (cs_b),
+      [alpha]    "m"  (alpha),
+      [beta]     "m"  (beta),
+      [c]        "m"  (c),
+      [rs_c]     "m"  (rs_c),
+      [cs_c]     "m"  (cs_c),
+      [mask_vec] "m"  (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r11", "r12", "r14",
+      "xmm0", "xmm2", "xmm3",
+      "xmm4", "xmm7",
+      "memory"
+    )
+}

--- a/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x8_mask.c
+++ b/kernels/zen/3/sup/s6x16/bli_gemmsup_rv_zen_asm_s5x8_mask.c
@@ -1,0 +1,1572 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2023 - 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "blis.h"
+
+#define BLIS_ASM_SYNTAX_ATT
+#include "bli_x86_asm_macros.h"
+
+static const int32_t mask[8][8] = { {0, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, 0, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, 0, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, 0, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, 0, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, 0, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, 0, 0},
+                                    {-1, -1, -1, -1, -1, -1, -1, 0},
+                                  };
+
+void bli_sgemmsup_rv_zen_asm_5x8_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,        4*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,4*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,4*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,        4*4)) // prefetch c + 3*rs_c
+    prefetch(0, mem(rdx, rdi, 1,4*4)) // prefetch c + 4*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    vbroadcastss(mem(rax, r8,  4), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm12)
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm7)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+    vmulps(ymm0, ymm12, ymm12)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm7)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm6)
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm8)
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm10)
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm12)
+    vmaskmovps(ymm12, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm12, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r13", "r14",
+      "xmm0", "xmm7",
+      "ymm0", "ymm2", "ymm3", "ymm4", "ymm6",
+      "ymm7", "ymm8", "ymm10", "ymm12",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_4x8_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)           //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    lea(mem(r8, r8, 2), r13)           // r13 = 3*rs_a
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    lea(mem(r12, rdi, 2), rdx)         //
+    lea(mem(rdx, rdi, 1), rdx)         // rdx = c + 3*rs_c;
+    prefetch(0, mem(r12,        4*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,4*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,4*4)) // prefetch c + 2*rs_c
+    prefetch(0, mem(rdx,        4*4)) // prefetch c + 3*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+    lea(mem(r9, r9, 2), rcx)           // rcx = 3*cs_a;
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+    vbroadcastss(mem(rax, r13, 1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm10)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm7)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+    vmulps(ymm0, ymm10, ymm10)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm7)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm6)
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm8)
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm10)
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm10, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r13", "r14",
+      "xmm0", "xmm7",
+      "ymm0", "ymm2", "ymm3", "ymm4", "ymm6",
+      "ymm7", "ymm8", "ymm10",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_3x8_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)            //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12,        4*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,4*4)) // prefetch c + 1*rs_c
+    prefetch(0, mem(r12, rdi, 2,4*4)) // prefetch c + 2*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+
+    // ---------------------------------- iteration 0
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    vbroadcastss(mem(rax, r8,  2), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm8)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm7)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+    vmulps(ymm0, ymm8, ymm8)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm7)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm6)
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm8)
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm8, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0", "xmm7",
+      "ymm0", "ymm2", "ymm3", "ymm4", "ymm6",
+      "ymm7", "ymm8",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_2x8_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)           //load mask elements
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+
+    prefetch(0, mem(r12,        4*4)) // prefetch c + 0*rs_c
+    prefetch(0, mem(r12, rdi, 1,4*4)) // prefetch c + 1*rs_c
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 2
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 3
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+    vbroadcastss(mem(rax, r8,  1), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm6)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm7)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+    vmulps(ymm0, ymm6, ymm6)
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm7)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0*32))
+
+    add(rdi, rcx)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm6)
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+    add(rdi, rcx)
+
+    vmaskmovps(ymm6, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"   (k_iter),
+      [k_left]     "m"   (k_left),
+      [a]          "m"   (a),
+      [rs_a]       "m"   (rs_a),
+      [cs_a]       "m"   (cs_a),
+      [ps_a4]      "m"   (ps_a4),
+      [b]          "m"   (b),
+      [rs_b]       "m"   (rs_b),
+      [cs_b]       "m"   (cs_b),
+      [alpha]      "m"   (alpha),
+      [beta]       "m"   (beta),
+      [c]          "m"   (c),
+      [rs_c]       "m"   (rs_c),
+      [cs_c]       "m"   (cs_c),
+      [mask_vec]   "m"   (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0", "xmm7",
+      "ymm0", "ymm2", "ymm3", "ymm4", "ymm6", "ymm7",
+      "memory"
+    )
+}
+
+void bli_sgemmsup_rv_zen_asm_1x8_mask
+     (
+             conj_t     conja,
+             conj_t     conjb,
+             dim_t      m0,
+             dim_t      n0,
+             dim_t      k0,
+       const void*      alpha,
+       const void*      a, inc_t rs_a0, inc_t cs_a0,
+       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      beta,
+             void*      c, inc_t rs_c0, inc_t cs_c0,
+       const auxinfo_t* data,
+       const cntx_t*    cntx
+     )
+{
+    // Typecast local copies of integers in case dim_t and inc_t are a
+    // different size than is expected by load instructions.
+    uint64_t k_iter = k0 / 4;
+    uint64_t k_left = k0 % 4;
+
+    uint64_t rs_a   = rs_a0;
+    uint64_t cs_a   = cs_a0;
+    uint64_t rs_b   = rs_b0;
+    uint64_t cs_b   = cs_b0;
+    uint64_t rs_c   = rs_c0;
+    uint64_t cs_c   = cs_c0;
+
+    // Query the panel stride of A and convert it to units of bytes.
+    uint64_t ps_a   = bli_auxinfo_ps_a( data );
+    uint64_t ps_a4  = ps_a * sizeof( float );
+
+    uint64_t n_mod8 = n0 % 8 ;
+    const int32_t *mask_vec = mask[n_mod8];
+    // -------------------------------------------------------------------------
+
+    begin_asm()
+
+    vzeroall()                         // zero all xmm/ymm registers.
+    mov(var(mask_vec), rdx)
+    vmovdqu(mem(rdx), ymm3)       //load
+
+    mov(var(a), r14)                   // load address of a.
+    mov(var(rs_a), r8)                 // load rs_a
+    mov(var(cs_a), r9)                 // load cs_a
+    lea(mem(, r8, 4), r8)              // rs_a *= sizeof(float)
+
+
+    lea(mem(, r9, 4), r9)              // cs_a *= sizeof(float)
+
+    mov(var(rs_b), r10)                // load rs_b
+    lea(mem(, r10, 4), r10)            // rs_b *= sizeof(float)
+
+                                       // NOTE: We cannot pre-load elements of a or b
+                                       // because it could eventually, in the last
+                                       // unrolled iter or the cleanup loop, result
+                                       // in reading beyond the bounds allocated mem
+                                       // (the likely result: a segmentation fault).
+
+    mov(var(c), r12)                   // load address of c
+    mov(var(rs_c), rdi)                // load rs_c
+    lea(mem(, rdi, 4), rdi)            // rs_c *= sizeof(float)
+
+
+    // During preamble and loops:
+    // r12 = rcx = c
+    // r14 = rax = a
+    // read rbx from var(b) near beginning of loop
+
+    mov(var(b), rbx)                   // load address of b.
+    mov(r14, rax)                      // reset rax to current upanel of a.
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOLPFETCH)                    // jump to column storage case
+    label(.SROWPFETCH)                 // row-stored prefetching on c
+
+    prefetch(0, mem(r12,        4*4)) // prefetch c + 0*rs
+
+    jmp(.SPOSTPFETCH)                  // jump to end of prefetching c
+    label(.SCOLPFETCH)                 // column-stored prefetching c
+
+    mov(var(cs_c), rsi)                // load cs_c to rsi (temporarily)
+    lea(mem(, rsi, 4), rsi)            // cs_c *= sizeof(float)
+    lea(mem(rsi, rsi, 2), rcx)         // rcx = 3*cs_c;
+    prefetch(0, mem(r12,         5*4)) // prefetch c + 0*cs_c
+    prefetch(0, mem(r12, rsi, 1, 5*4)) // prefetch c + 1*cs_c
+    prefetch(0, mem(r12, rsi, 2, 5*4)) // prefetch c + 2*cs_c
+    prefetch(0, mem(r12, rcx, 1, 5*4)) // prefetch c + 3*cs_c
+    prefetch(0, mem(r12, rsi, 4, 5*4)) // prefetch c + 4*cs_c
+    lea(mem(r12, rsi, 4), rdx)         // rdx = c + 4*cs_c;
+    prefetch(0, mem(rdx, rsi, 1, 5*4)) // prefetch c + 5*cs_c
+    prefetch(0, mem(rdx, rsi, 2, 5*4)) // prefetch c + 6*cs_c
+
+    label(.SPOSTPFETCH)                // done prefetching c
+
+    mov(var(ps_a4), rdx)               // load ps_a4
+    lea(mem(rax, rdx, 1), rdx)         // rdx = a + ps_a4
+                                       // use rcx, rdx for prefetching lines
+                                       // from next upanel of a.
+
+    mov(var(k_iter), rsi)              // i = k_iter;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SCONSIDKLEFT)                  // if i == 0, jump to code that
+                                       // contains the k_left loop.
+
+    label(.SLOOPKITER)                 // MAIN LOOP
+
+    // ---------------------------------- iteration 0
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    // ---------------------------------- iteration 1
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+
+    // ---------------------------------- iteration 2
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+
+    // ---------------------------------- iteration 3
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKITER)                   // iterate again if i != 0.
+
+    label(.SCONSIDKLEFT)
+
+    mov(var(k_left), rsi)              // i = k_left;
+    test(rsi, rsi)                     // check i via logical AND.
+    je(.SPOSTACCUM)                    // if i == 0, we're done; jump to end.
+                                       // ee, we prepare to enter k_left loop.
+
+    label(.SLOOPKLEFT)                 // EDGE LOOP
+
+    prefetch(0, mem(rdx, 5*8))
+    add(r9, rdx)
+
+    vmaskmovps(mem(rbx, 0*32), ymm3, ymm0)
+    add(r10, rbx)                      // b += rs_b;
+
+    vbroadcastss(mem(rax        ), ymm2)
+    vfmadd231ps(ymm0, ymm2, ymm4)
+
+    add(r9, rax)                       // a += cs_a;
+
+    dec(rsi)                           // i -= 1;
+    jne(.SLOOPKLEFT)                   // iterate again if i != 0.
+
+    label(.SPOSTACCUM)
+
+    mov(r12, rcx)                      // reset rcx to current utile of c.
+    mov(var(alpha), rax)               // load address of alpha
+    mov(var(beta), rbx)                // load address of beta
+    vbroadcastss(mem(rax), ymm0)       // load alpha and duplicate
+    vbroadcastss(mem(rbx), ymm7)       // load beta and duplicate
+
+    vmulps(ymm0, ymm4, ymm4)           // scale by alpha
+
+    mov(var(cs_c), rsi)                // load cs_c
+    lea(mem(, rsi, 4), rsi)            // rsi = cs_c * sizeof(float)
+
+    lea(mem(rcx, rdi, 4), rdx)         // load address of c +  4*rs_c;
+
+    lea(mem(rsi, rsi, 2), rax)         // rax = 3*cs_c;
+    lea(mem(rsi, rsi, 4), rbx)         // rbx = 5*cs_c;
+
+                                       // now avoid loading C if beta == 0
+
+    vxorps(ymm0, ymm0, ymm0)           // set ymm0 to zero.
+    vucomiss(xmm0, xmm7)               // set ZF if beta == 0.
+    je(.SBETAZERO)                     // if ZF = 1, jump to beta == 0 case
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORED)                    // jump to column storage case
+
+    label(.SROWSTORED)
+
+    vmaskmovps(mem(rcx, 0*32), ymm3, ymm2)
+    vfmadd231ps(ymm2, ymm7, ymm4)
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0*32))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORED)
+
+    /* TODO: Add column storage support*/
+
+    label(.SBETAZERO)
+
+    cmp(imm(4), rdi)                   // set ZF if (4*rs_c) == 4.
+    jz(.SCOTORBZ)                    // jump to column storage case
+
+    label(.SROWSTORBZ)
+
+    vmaskmovps(ymm4, ymm3, mem(rcx, 0))
+
+    jmp(.SDONE)                        // jump to end.
+
+    label(.SCOTORBZ)
+
+    /* TODO: Add column storage support*/
+
+    label(.SDONE)
+
+    label(.SRETURN)
+
+    end_asm(
+    : // output operands (none)
+    : // input operands
+      [k_iter]     "m"    (k_iter),
+      [k_left]     "m"    (k_left),
+      [a]          "m"    (a),
+      [rs_a]       "m"    (rs_a),
+      [cs_a]       "m"    (cs_a),
+      [ps_a4]      "m"    (ps_a4),
+      [b]          "m"    (b),
+      [rs_b]       "m"    (rs_b),
+      [cs_b]       "m"    (cs_b),
+      [alpha]      "m"    (alpha),
+      [beta]       "m"    (beta),
+      [c]          "m"    (c),
+      [rs_c]       "m"    (rs_c),
+      [cs_c]       "m"    (cs_c),
+      [mask_vec]   "m"    (mask_vec)
+    : // register clobber list
+      "rax", "rbx", "rcx", "rdx", "rsi", "rdi",
+      "r8", "r9", "r10", "r12", "r14",
+      "xmm0", "xmm7",
+      "ymm0", "ymm2", "ymm3", "ymm4", "ymm7",
+      "memory"
+    )
+}
+

--- a/kernels/zen/bli_kernels_zen.h
+++ b/kernels/zen/bli_kernels_zen.h
@@ -5,7 +5,7 @@
    libraries.
 
    Copyright (C) 2014, The University of Texas at Austin
-   Copyright (C) 2020 - 2022, Advanced Micro Devices, Inc. All rights reserved.
+   Copyright (C) 2020 - 2025, Advanced Micro Devices, Inc. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are
@@ -126,7 +126,7 @@ GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_2x8 )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_1x8 )
 
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x4 )
-GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_5x4 ) 
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_5x4 )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_4x4 )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_3x4 )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_2x4 )
@@ -151,6 +151,33 @@ GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x16m )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x8m )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x4m )
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x2m )
+//gemmsup_rv (mkernel in m dim) for mask load/store
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x16m_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x8m_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x4m_mask )
+GEMMSUP_KER_PROT( float,   s, bli_sgemmsup_rv_zen_asm_6x8m )
+GEMMSUP_KER_PROT( float,   s, bli_sgemmsup_rv_zen_asm_6x4m )
+GEMMSUP_KER_PROT( float,   s, bli_sgemmsup_rv_zen_asm_6x2m )
+
+//gemmsup_rv (mkernel in m dim) for fringe case
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_1x16_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_2x16_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_3x16_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_4x16_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_5x16_mask )
+
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_1x8_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_2x8_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_3x8_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_4x8_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_5x8_mask )
+
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_1x4_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_2x4_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_3x4_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_4x4_mask )
+GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_5x4_mask )
+
 // gemmsup_rv (mkernel in n dim)
 
 GEMMSUP_KER_PROT( float,   s, gemmsup_rv_zen_asm_6x16n )
@@ -180,34 +207,4 @@ GEMMSUP_KER_PROT( float,   s, gemmsup_rd_zen_asm_6x16n)
 GEMMSUP_KER_PROT( float,   s, gemmsup_rd_zen_asm_3x16n)
 GEMMSUP_KER_PROT( float,   s, gemmsup_rd_zen_asm_2x16n)
 GEMMSUP_KER_PROT( float,   s, gemmsup_rd_zen_asm_1x16n)
-
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x8m )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x4m )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x2m )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_2x8 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_1x8 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_2x4 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_1x4 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_2x2 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_1x2 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_3x4m )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_3x2m )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_2x4 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_1x4 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_2x2 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_1x2 )
-
-// gemmsup_rv (mkernel in n dim)
-
-
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x8n )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_2x8n )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_1x8n )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x4 )
-GEMMSUP_KER_PROT( scomplex,   c, gemmsup_rv_zen_asm_3x2 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_3x4n )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_2x4n )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_1x4n )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_3x2 )
-GEMMSUP_KER_PROT( dcomplex,   z, gemmsup_rv_zen_asm_3x1 )
 


### PR DESCRIPTION
- Added optimized sgemm sup kernels for AMD zen.
- Support masked load/store instructions (`vmaskmovps` / `VMASKMOVPS`) for edge and fringe kernels in row-storage format.
- Improves performance by reducing branch overhead and enhancing cache behavior.
- Fixed compiler warning for dgemm sup kernels.