### PR TITLE
Added new AVX2 AXPYV and AXPYF optimized kernels

### DIFF
--- a/config/haswell/bli_cntx_init_haswell.c
+++ b/config/haswell/bli_cntx_init_haswell.c
@@ -93,8 +93,10 @@ void bli_cntx_init_haswell( cntx_t* cntx )
 	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int,
 	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int,
 #else
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 #endif
 	  // dotv
 	  BLIS_DOTV_KER,   BLIS_FLOAT,  bli_sdotv_zen_int,

--- a/config/haswell/bli_cntx_init_haswell.c
+++ b/config/haswell/bli_cntx_init_haswell.c
@@ -80,6 +80,8 @@ void bli_cntx_init_haswell( cntx_t* cntx )
 	  // axpyf
 	  BLIS_AXPYF_KER,     BLIS_FLOAT,  bli_saxpyf_zen_int_8,
 	  BLIS_AXPYF_KER,     BLIS_DOUBLE, bli_daxpyf_zen_int_8,
+	  BLIS_AXPYF_KER,     BLIS_SCOMPLEX,  bli_caxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,     BLIS_DCOMPLEX, bli_zaxpyf_zen_int_5,
 	  // dotxf
 	  BLIS_DOTXF_KER,     BLIS_FLOAT,  bli_sdotxf_zen_int_8,
 	  BLIS_DOTXF_KER,     BLIS_DOUBLE, bli_ddotxf_zen_int_8,
@@ -202,7 +204,7 @@ void bli_cntx_init_haswell( cntx_t* cntx )
 	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   256 );
 #endif
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,  4080 );
-	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,     8,     8 );
+	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,     5,     5 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,     8,     8 );
 
 	// -------------------------------------------------------------------------

--- a/config/knl/bli_cntx_init_knl.c
+++ b/config/knl/bli_cntx_init_knl.c
@@ -74,8 +74,10 @@ void bli_cntx_init_knl( cntx_t* cntx )
 	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int,
 	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int,
 #else
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 #endif
 
 	  // dotv

--- a/config/old/haswellbb/bli_cntx_init_haswell.c
+++ b/config/old/haswellbb/bli_cntx_init_haswell.c
@@ -160,8 +160,10 @@ void bli_cntx_init_haswell( cntx_t* cntx )
 	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int,
 	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int,
 #else
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 #endif
 	  // dotv
 	  BLIS_DOTV_KER,   BLIS_FLOAT,  bli_sdotv_zen_int,

--- a/config/skx/bli_cntx_init_skx.c
+++ b/config/skx/bli_cntx_init_skx.c
@@ -55,6 +55,8 @@ void bli_cntx_init_skx( cntx_t* cntx )
 	  // axpyf
 	  BLIS_AXPYF_KER,     BLIS_FLOAT,  bli_saxpyf_zen_int_8,
 	  BLIS_AXPYF_KER,     BLIS_DOUBLE, bli_daxpyf_zen_int_8,
+	  BLIS_AXPYF_KER,     BLIS_SCOMPLEX,  bli_caxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,     BLIS_DCOMPLEX, bli_zaxpyf_zen_int_5,
 
 	  // dotxf
 	  BLIS_DOTXF_KER,     BLIS_FLOAT,  bli_sdotxf_zen_int_8,
@@ -117,7 +119,7 @@ void bli_cntx_init_skx( cntx_t* cntx )
 	bli_blksz_init     ( &blkszs[ BLIS_KC ],   384,   256,    -1,    -1,
 	                                           480,   320,    -1,    -1 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  3072,  3752,    -1,    -1 );
-	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,    5,    5 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );
 
 	// Update the context with the current architecture's register and cache

--- a/config/skx/bli_cntx_init_skx.c
+++ b/config/skx/bli_cntx_init_skx.c
@@ -71,8 +71,10 @@ void bli_cntx_init_skx( cntx_t* cntx )
 	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int,
 	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int,
 #else
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 #endif
 
 	  // dotv

--- a/config/zen/bli_cntx_init_zen.c
+++ b/config/zen/bli_cntx_init_zen.c
@@ -131,8 +131,10 @@ void bli_cntx_init_zen( cntx_t* cntx )
 	  BLIS_AMAXV_KER,  BLIS_DOUBLE, bli_damaxv_zen_int,
 
 	  // axpyv
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 
 	  // copyv
 	  BLIS_COPYV_KER,  BLIS_FLOAT,  bli_scopyv_zen_int,

--- a/config/zen/bli_cntx_init_zen.c
+++ b/config/zen/bli_cntx_init_zen.c
@@ -121,6 +121,8 @@ void bli_cntx_init_zen( cntx_t* cntx )
 	  // axpyf
 	  BLIS_AXPYF_KER,  BLIS_FLOAT,  bli_saxpyf_zen_int_8,
 	  BLIS_AXPYF_KER,  BLIS_DOUBLE, bli_daxpyf_zen_int_8,
+	  BLIS_AXPYF_KER,  BLIS_SCOMPLEX, bli_caxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,  BLIS_DCOMPLEX, bli_zaxpyf_zen_int_5,
 
 	  // dotxf
 	  BLIS_DOTXF_KER,  BLIS_FLOAT,  bli_sdotxf_zen_int_8,
@@ -256,7 +258,7 @@ void bli_cntx_init_zen( cntx_t* cntx )
 	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   256 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  8160,  4080,  4080,  3056 );
 #endif
-	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,    5,    5 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );
 
 	// Initialize sup thresholds with architecture-appropriate values.

--- a/config/zen2/bli_cntx_init_zen2.c
+++ b/config/zen2/bli_cntx_init_zen2.c
@@ -128,8 +128,10 @@ void bli_cntx_init_zen2( cntx_t* cntx )
 	  BLIS_AMAXV_KER,  BLIS_DOUBLE, bli_damaxv_zen_int,
 
 	  // axpyv
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 
 	  // dotv
 	  BLIS_DOTV_KER,   BLIS_FLOAT,  bli_sdotv_zen_int10,

--- a/config/zen2/bli_cntx_init_zen2.c
+++ b/config/zen2/bli_cntx_init_zen2.c
@@ -118,6 +118,8 @@ void bli_cntx_init_zen2( cntx_t* cntx )
 	  // axpyf
 	  BLIS_AXPYF_KER,  BLIS_FLOAT,  bli_saxpyf_zen_int_5,
 	  BLIS_AXPYF_KER,  BLIS_DOUBLE, bli_daxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,  BLIS_SCOMPLEX, bli_caxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,  BLIS_DCOMPLEX, bli_zaxpyf_zen_int_5,
 
 	  // dotxf
 	  BLIS_DOTXF_KER,  BLIS_FLOAT,  bli_sdotxf_zen_int_8,
@@ -215,7 +217,7 @@ void bli_cntx_init_zen2( cntx_t* cntx )
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,  4080 );
 #endif
 
-	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     5,     5,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     5,     5,    5,    5 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );
 
 	// Initialize sup thresholds with architecture-appropriate values.

--- a/config/zen3/bli_cntx_init_zen3.c
+++ b/config/zen3/bli_cntx_init_zen3.c
@@ -94,6 +94,8 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	  // axpyf
 	  BLIS_AXPYF_KER,  BLIS_FLOAT,  bli_saxpyf_zen_int_5,
 	  BLIS_AXPYF_KER,  BLIS_DOUBLE, bli_daxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,  BLIS_SCOMPLEX, bli_caxpyf_zen_int_5,
+	  BLIS_AXPYF_KER,  BLIS_DCOMPLEX, bli_zaxpyf_zen_int_5,
 
 	  // dotxf
 	  BLIS_DOTXF_KER,  BLIS_FLOAT,  bli_sdotxf_zen_int_8,
@@ -203,7 +205,7 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   566 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,   256 );
 
-	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     5,     5,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     5,     5,    5,    5 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );
 
 	// Initialize sup thresholds with architecture-appropriate values.

--- a/config/zen3/bli_cntx_init_zen3.c
+++ b/config/zen3/bli_cntx_init_zen3.c
@@ -139,8 +139,10 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	  BLIS_AMAXV_KER,  BLIS_DOUBLE, bli_damaxv_zen_int,
 
 	  // axpyv
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 
 	  // dotv
 	  BLIS_DOTV_KER,   BLIS_FLOAT,  bli_sdotv_zen_int10,

--- a/config/zen3/bli_cntx_init_zen3.c
+++ b/config/zen3/bli_cntx_init_zen3.c
@@ -104,8 +104,10 @@ void bli_cntx_init_zen3( cntx_t* cntx )
 	  BLIS_AMAXV_KER,  BLIS_DOUBLE, bli_damaxv_zen_int,
 
 	  // axpyv
-	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int10,
-	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int10,
+	  BLIS_AXPYV_KER,  BLIS_FLOAT,  bli_saxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_DOUBLE, bli_daxpyv_zen_int_10,
+	  BLIS_AXPYV_KER,  BLIS_SCOMPLEX,  bli_caxpyv_zen_int_5,
+	  BLIS_AXPYV_KER,  BLIS_DCOMPLEX, bli_zaxpyv_zen_int_5,
 
 	  // dotv
 	  BLIS_DOTV_KER,   BLIS_FLOAT,  bli_sdotv_zen_int10,

--- a/kernels/zen/1/bli_axpyv_zen_int10.c
+++ b/kernels/zen/1/bli_axpyv_zen_int10.c
@@ -4,8 +4,8 @@
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
-   Copyright (C) 2016 - 2019, Advanced Micro Devices, Inc.
-   Copyright (C) 2018, The University of Texas at Austin
+   Copyright (C) 2016 - 2025, Advanced Micro Devices, Inc. All rights reserved.
+   Copyright (C) 2018 - 2020, The University of Texas at Austin. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are
@@ -41,429 +41,1126 @@
    One 256-bit AVX register holds 8 SP elements. */
 typedef union
 {
-	__m256  v;
-	float   f[8] __attribute__((aligned(64)));
+    __m256  v;
+    float   f[8] __attribute__((aligned(64)));
 } v8sf_t;
 
 /* Union data structure to access AVX registers
 *  One 256-bit AVX register holds 4 DP elements. */
 typedef union
 {
-	__m256d v;
-	double  d[4] __attribute__((aligned(64)));
+    __m256d v;
+    double  d[4] __attribute__((aligned(64)));
 } v4df_t;
 
 // -----------------------------------------------------------------------------
 
-void bli_saxpyv_zen_int10
+void bli_saxpyv_zen_int_10
      (
              conj_t  conjx,
              dim_t   n,
-       const void*   alpha0,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   alpha00,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const float*     alpha = alpha0;
-	const float*     x     = x0;
-	      float*     y     = y0;
+	float *alpha = (float *)alpha00;
+	float *x     = (float *)x00;
+	float *y     = (float *)y00;
 
-	const dim_t      n_elem_per_reg = 8;
+    const dim_t      n_elem_per_reg = 8;
 
-	dim_t            i;
+    dim_t            i;
 
-	__m256           alphav;
-	__m256           xv[10];
-	__m256           yv[10];
-	__m256           zv[10];
+    float*  restrict x0;
+    float*  restrict y0;
 
-	// If the vector dimension is zero, or if alpha is zero, return early.
-	if ( bli_zero_dim1( n ) || PASTEMAC(s,eq0)( *alpha ) ) return;
+    __m256           alphav;
+    __m256           xv[15];
+    __m256           yv[15];
+    __m256           zv[15];
 
-	// Initialize local pointers.
-	const float* restrict xp = x;
-	      float* restrict yp = y;
+    // If the vector dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim1( n ) || PASTEMAC(s,eq0)( *alpha ) )
+    {
+        return;
+    }
 
-	if ( incx == 1 && incy == 1 )
-	{
-		// Broadcast the alpha scalar to all elements of a vector register.
-		alphav = _mm256_broadcast_ss( alpha );
+    // Initialize local pointers.
+    x0 = x;
+    y0 = y;
 
-		for ( i = 0; (i + 79) < n; i += 80 )
-		{
-			// 80 elements will be processed per loop; 10 FMAs will run per loop.
-			xv[0] = _mm256_loadu_ps( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_ps( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_ps( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_ps( xp + 3*n_elem_per_reg );
-			xv[4] = _mm256_loadu_ps( xp + 4*n_elem_per_reg );
-			xv[5] = _mm256_loadu_ps( xp + 5*n_elem_per_reg );
-			xv[6] = _mm256_loadu_ps( xp + 6*n_elem_per_reg );
-			xv[7] = _mm256_loadu_ps( xp + 7*n_elem_per_reg );
-			xv[8] = _mm256_loadu_ps( xp + 8*n_elem_per_reg );
-			xv[9] = _mm256_loadu_ps( xp + 9*n_elem_per_reg );
+    if ( incx == 1 && incy == 1 )
+    {
+        // Broadcast the alpha scalar to all elements of a vector register.
+        alphav = _mm256_broadcast_ss( alpha );
 
-			yv[0] = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_ps( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_ps( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_ps( yp + 3*n_elem_per_reg );
-			yv[4] = _mm256_loadu_ps( yp + 4*n_elem_per_reg );
-			yv[5] = _mm256_loadu_ps( yp + 5*n_elem_per_reg );
-			yv[6] = _mm256_loadu_ps( yp + 6*n_elem_per_reg );
-			yv[7] = _mm256_loadu_ps( yp + 7*n_elem_per_reg );
-			yv[8] = _mm256_loadu_ps( yp + 8*n_elem_per_reg );
-			yv[9] = _mm256_loadu_ps( yp + 9*n_elem_per_reg );
+        for (i = 0; (i + 119) < n; i += 120)
+        {
+            // 120 elements will be processed per loop; 15 FMAs will run per loop.
+            xv[0] = _mm256_loadu_ps(x0 + 0 * n_elem_per_reg);
+            xv[1] = _mm256_loadu_ps(x0 + 1 * n_elem_per_reg);
+            xv[2] = _mm256_loadu_ps(x0 + 2 * n_elem_per_reg);
+            xv[3] = _mm256_loadu_ps(x0 + 3 * n_elem_per_reg);
+            xv[4] = _mm256_loadu_ps(x0 + 4 * n_elem_per_reg);
+            xv[5] = _mm256_loadu_ps(x0 + 5 * n_elem_per_reg);
+            xv[6] = _mm256_loadu_ps(x0 + 6 * n_elem_per_reg);
+            xv[7] = _mm256_loadu_ps(x0 + 7 * n_elem_per_reg);
+            xv[8] = _mm256_loadu_ps(x0 + 8 * n_elem_per_reg);
+            xv[9] = _mm256_loadu_ps(x0 + 9 * n_elem_per_reg);
+            xv[10] = _mm256_loadu_ps(x0 + 10 * n_elem_per_reg);
+            xv[11] = _mm256_loadu_ps(x0 + 11 * n_elem_per_reg);
+            xv[12] = _mm256_loadu_ps(x0 + 12 * n_elem_per_reg);
+            xv[13] = _mm256_loadu_ps(x0 + 13 * n_elem_per_reg);
+            xv[14] = _mm256_loadu_ps(x0 + 14 * n_elem_per_reg);
 
-			zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
-			zv[4] = _mm256_fmadd_ps( xv[4], alphav, yv[4] );
-			zv[5] = _mm256_fmadd_ps( xv[5], alphav, yv[5] );
-			zv[6] = _mm256_fmadd_ps( xv[6], alphav, yv[6] );
-			zv[7] = _mm256_fmadd_ps( xv[7], alphav, yv[7] );
-			zv[8] = _mm256_fmadd_ps( xv[8], alphav, yv[8] );
-			zv[9] = _mm256_fmadd_ps( xv[9], alphav, yv[9] );
+            yv[0] = _mm256_loadu_ps(y0 + 0 * n_elem_per_reg);
+            yv[1] = _mm256_loadu_ps(y0 + 1 * n_elem_per_reg);
+            yv[2] = _mm256_loadu_ps(y0 + 2 * n_elem_per_reg);
+            yv[3] = _mm256_loadu_ps(y0 + 3 * n_elem_per_reg);
+            yv[4] = _mm256_loadu_ps(y0 + 4 * n_elem_per_reg);
+            yv[5] = _mm256_loadu_ps(y0 + 5 * n_elem_per_reg);
+            yv[6] = _mm256_loadu_ps(y0 + 6 * n_elem_per_reg);
+            yv[7] = _mm256_loadu_ps(y0 + 7 * n_elem_per_reg);
+            yv[8] = _mm256_loadu_ps(y0 + 8 * n_elem_per_reg);
+            yv[9] = _mm256_loadu_ps(y0 + 9 * n_elem_per_reg);
+            yv[10] = _mm256_loadu_ps(y0 + 10 * n_elem_per_reg);
+            yv[11] = _mm256_loadu_ps(y0 + 11 * n_elem_per_reg);
+            yv[12] = _mm256_loadu_ps(y0 + 12 * n_elem_per_reg);
+            yv[13] = _mm256_loadu_ps(y0 + 13 * n_elem_per_reg);
+            yv[14] = _mm256_loadu_ps(y0 + 14 * n_elem_per_reg);
 
-			_mm256_storeu_ps( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_ps( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_ps( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_ps( (yp + 3*n_elem_per_reg), zv[3] );
-			_mm256_storeu_ps( (yp + 4*n_elem_per_reg), zv[4] );
-			_mm256_storeu_ps( (yp + 5*n_elem_per_reg), zv[5] );
-			_mm256_storeu_ps( (yp + 6*n_elem_per_reg), zv[6] );
-			_mm256_storeu_ps( (yp + 7*n_elem_per_reg), zv[7] );
-			_mm256_storeu_ps( (yp + 8*n_elem_per_reg), zv[8] );
-			_mm256_storeu_ps( (yp + 9*n_elem_per_reg), zv[9] );
+            zv[0] = _mm256_fmadd_ps(xv[0], alphav, yv[0]);
+            zv[1] = _mm256_fmadd_ps(xv[1], alphav, yv[1]);
+            zv[2] = _mm256_fmadd_ps(xv[2], alphav, yv[2]);
+            zv[3] = _mm256_fmadd_ps(xv[3], alphav, yv[3]);
+            zv[4] = _mm256_fmadd_ps(xv[4], alphav, yv[4]);
+            zv[5] = _mm256_fmadd_ps(xv[5], alphav, yv[5]);
+            zv[6] = _mm256_fmadd_ps(xv[6], alphav, yv[6]);
+            zv[7] = _mm256_fmadd_ps(xv[7], alphav, yv[7]);
+            zv[8] = _mm256_fmadd_ps(xv[8], alphav, yv[8]);
+            zv[9] = _mm256_fmadd_ps(xv[9], alphav, yv[9]);
+            zv[10] = _mm256_fmadd_ps(xv[10], alphav, yv[10]);
+            zv[11] = _mm256_fmadd_ps(xv[11], alphav, yv[11]);
+            zv[12] = _mm256_fmadd_ps(xv[12], alphav, yv[12]);
+            zv[13] = _mm256_fmadd_ps(xv[13], alphav, yv[13]);
+            zv[14] = _mm256_fmadd_ps(xv[14], alphav, yv[14]);
 
-			xp += 10*n_elem_per_reg;
-			yp += 10*n_elem_per_reg;
-		}
+            _mm256_storeu_ps((y0 + 0 * n_elem_per_reg), zv[0]);
+            _mm256_storeu_ps((y0 + 1 * n_elem_per_reg), zv[1]);
+            _mm256_storeu_ps((y0 + 2 * n_elem_per_reg), zv[2]);
+            _mm256_storeu_ps((y0 + 3 * n_elem_per_reg), zv[3]);
+            _mm256_storeu_ps((y0 + 4 * n_elem_per_reg), zv[4]);
+            _mm256_storeu_ps((y0 + 5 * n_elem_per_reg), zv[5]);
+            _mm256_storeu_ps((y0 + 6 * n_elem_per_reg), zv[6]);
+            _mm256_storeu_ps((y0 + 7 * n_elem_per_reg), zv[7]);
+            _mm256_storeu_ps((y0 + 8 * n_elem_per_reg), zv[8]);
+            _mm256_storeu_ps((y0 + 9 * n_elem_per_reg), zv[9]);
+            _mm256_storeu_ps((y0 + 10 * n_elem_per_reg), zv[10]);
+            _mm256_storeu_ps((y0 + 11 * n_elem_per_reg), zv[11]);
+            _mm256_storeu_ps((y0 + 12 * n_elem_per_reg), zv[12]);
+            _mm256_storeu_ps((y0 + 13 * n_elem_per_reg), zv[13]);
+            _mm256_storeu_ps((y0 + 14 * n_elem_per_reg), zv[14]);
 
-		for ( ; (i + 39) < n; i += 40 )
-		{
-			xv[0] = _mm256_loadu_ps( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_ps( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_ps( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_ps( xp + 3*n_elem_per_reg );
-			xv[4] = _mm256_loadu_ps( xp + 4*n_elem_per_reg );
+            x0 += 15 * n_elem_per_reg;
+            y0 += 15 * n_elem_per_reg;
+        }
 
-			yv[0] = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_ps( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_ps( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_ps( yp + 3*n_elem_per_reg );
-			yv[4] = _mm256_loadu_ps( yp + 4*n_elem_per_reg );
+        for (; (i + 79) < n; i += 80 )
+        {
+            // 80 elements will be processed per loop; 10 FMAs will run per loop.
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_ps( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_ps( x0 + 3*n_elem_per_reg );
+            xv[4] = _mm256_loadu_ps( x0 + 4*n_elem_per_reg );
+            xv[5] = _mm256_loadu_ps( x0 + 5*n_elem_per_reg );
+            xv[6] = _mm256_loadu_ps( x0 + 6*n_elem_per_reg );
+            xv[7] = _mm256_loadu_ps( x0 + 7*n_elem_per_reg );
+            xv[8] = _mm256_loadu_ps( x0 + 8*n_elem_per_reg );
+            xv[9] = _mm256_loadu_ps( x0 + 9*n_elem_per_reg );
 
-			zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
-			zv[4] = _mm256_fmadd_ps( xv[4], alphav, yv[4] );
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_ps( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_ps( y0 + 3*n_elem_per_reg );
+            yv[4] = _mm256_loadu_ps( y0 + 4*n_elem_per_reg );
+            yv[5] = _mm256_loadu_ps( y0 + 5*n_elem_per_reg );
+            yv[6] = _mm256_loadu_ps( y0 + 6*n_elem_per_reg );
+            yv[7] = _mm256_loadu_ps( y0 + 7*n_elem_per_reg );
+            yv[8] = _mm256_loadu_ps( y0 + 8*n_elem_per_reg );
+            yv[9] = _mm256_loadu_ps( y0 + 9*n_elem_per_reg );
 
-			_mm256_storeu_ps( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_ps( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_ps( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_ps( (yp + 3*n_elem_per_reg), zv[3] );
-			_mm256_storeu_ps( (yp + 4*n_elem_per_reg), zv[4] );
+            zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
+            zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
+            zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
+            zv[4] = _mm256_fmadd_ps( xv[4], alphav, yv[4] );
+            zv[5] = _mm256_fmadd_ps( xv[5], alphav, yv[5] );
+            zv[6] = _mm256_fmadd_ps( xv[6], alphav, yv[6] );
+            zv[7] = _mm256_fmadd_ps( xv[7], alphav, yv[7] );
+            zv[8] = _mm256_fmadd_ps( xv[8], alphav, yv[8] );
+            zv[9] = _mm256_fmadd_ps( xv[9], alphav, yv[9] );
 
-			xp += 5*n_elem_per_reg;
-			yp += 5*n_elem_per_reg;
-		}
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), zv[1] );
+            _mm256_storeu_ps( (y0 + 2*n_elem_per_reg), zv[2] );
+            _mm256_storeu_ps( (y0 + 3*n_elem_per_reg), zv[3] );
+            _mm256_storeu_ps( (y0 + 4*n_elem_per_reg), zv[4] );
+            _mm256_storeu_ps( (y0 + 5*n_elem_per_reg), zv[5] );
+            _mm256_storeu_ps( (y0 + 6*n_elem_per_reg), zv[6] );
+            _mm256_storeu_ps( (y0 + 7*n_elem_per_reg), zv[7] );
+            _mm256_storeu_ps( (y0 + 8*n_elem_per_reg), zv[8] );
+            _mm256_storeu_ps( (y0 + 9*n_elem_per_reg), zv[9] );
 
-		for ( ; (i + 31) < n; i += 32 )
-		{
-			xv[0] = _mm256_loadu_ps( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_ps( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_ps( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_ps( xp + 3*n_elem_per_reg );
+            x0 += 10*n_elem_per_reg;
+            y0 += 10*n_elem_per_reg;
+        }
 
-			yv[0] = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_ps( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_ps( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_ps( yp + 3*n_elem_per_reg );
+        for ( ; (i + 39) < n; i += 40 )
+        {
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_ps( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_ps( x0 + 3*n_elem_per_reg );
+            xv[4] = _mm256_loadu_ps( x0 + 4*n_elem_per_reg );
 
-			zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_ps( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_ps( y0 + 3*n_elem_per_reg );
+            yv[4] = _mm256_loadu_ps( y0 + 4*n_elem_per_reg );
 
-			_mm256_storeu_ps( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_ps( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_ps( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_ps( (yp + 3*n_elem_per_reg), zv[3] );
+            zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
+            zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
+            zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
+            zv[4] = _mm256_fmadd_ps( xv[4], alphav, yv[4] );
 
-			xp += 4*n_elem_per_reg;
-			yp += 4*n_elem_per_reg;
-		}
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), zv[1] );
+            _mm256_storeu_ps( (y0 + 2*n_elem_per_reg), zv[2] );
+            _mm256_storeu_ps( (y0 + 3*n_elem_per_reg), zv[3] );
+            _mm256_storeu_ps( (y0 + 4*n_elem_per_reg), zv[4] );
 
-		for ( ; (i + 15) < n; i += 16 )
-		{
-			xv[0] = _mm256_loadu_ps( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_ps( xp + 1*n_elem_per_reg );
+            x0 += 5*n_elem_per_reg;
+            y0 += 5*n_elem_per_reg;
+        }
 
-			yv[0] = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_ps( yp + 1*n_elem_per_reg );
+        for ( ; (i + 31) < n; i += 32 )
+        {
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_ps( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_ps( x0 + 3*n_elem_per_reg );
 
-			zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_ps( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_ps( y0 + 3*n_elem_per_reg );
 
-			_mm256_storeu_ps( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_ps( (yp + 1*n_elem_per_reg), zv[1] );
+            zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
+            zv[2] = _mm256_fmadd_ps( xv[2], alphav, yv[2] );
+            zv[3] = _mm256_fmadd_ps( xv[3], alphav, yv[3] );
 
-			xp += 2*n_elem_per_reg;
-			yp += 2*n_elem_per_reg;
-		}
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), zv[1] );
+            _mm256_storeu_ps( (y0 + 2*n_elem_per_reg), zv[2] );
+            _mm256_storeu_ps( (y0 + 3*n_elem_per_reg), zv[3] );
 
-		for ( ; (i + 7) < n; i += 8 )
-		{
-			xv[0] = _mm256_loadu_ps( xp + 0*n_elem_per_reg );
+            x0 += 4*n_elem_per_reg;
+            y0 += 4*n_elem_per_reg;
+        }
 
-			yv[0] = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
+        for ( ; (i + 15) < n; i += 16 )
+        {
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
 
-			zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
 
-			_mm256_storeu_ps( (yp + 0*n_elem_per_reg), zv[0] );
+            zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_ps( xv[1], alphav, yv[1] );
 
-			xp += 1*n_elem_per_reg;
-			yp += 1*n_elem_per_reg;
-		}
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), zv[1] );
 
-		// Issue vzeroupper instruction to clear upper lanes of ymm registers.
-		// This avoids a performance penalty caused by false dependencies when
-		// transitioning from from AVX to SSE instructions (which may occur
-		// as soon as the n_left cleanup loop below if BLIS is compiled with
-		// -mfpmath=sse).
-		_mm256_zeroupper();
+            x0 += 2*n_elem_per_reg;
+            y0 += 2*n_elem_per_reg;
+        }
 
-		for ( ; (i + 0) < n; i += 1 )
-		{
-			*yp += (*alpha) * (*xp);
+        for ( ; (i + 7) < n; i += 8 )
+        {
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
 
-			xp += 1;
-			yp += 1;
-		}
-	}
-	else
-	{
-		const float alphac = *alpha;
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
 
-		for ( i = 0; i < n; ++i )
-		{
-			const float xpc = *xp;
+            zv[0] = _mm256_fmadd_ps( xv[0], alphav, yv[0] );
 
-			*yp += alphac * xpc;
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), zv[0] );
 
-			xp += incx;
-			yp += incy;
-		}
-	}
+            x0 += 1*n_elem_per_reg;
+            y0 += 1*n_elem_per_reg;
+        }
+
+        // Issue vzeroupper instruction to clear upper lanes of ymm registers.
+        // This avoids a performance penalty caused by false dependencies when
+        // transitioning from AVX to SSE instructions (which may occur as soon
+        // as the n_left cleanup loop below if BLIS is compiled with
+        // -mfpmath=sse).
+
+        _mm256_zeroupper();
+
+        for ( ; (i + 0) < n; i += 1 )
+        {
+            *y0 += (*alpha) * (*x0);
+
+            x0 += 1;
+            y0 += 1;
+        }
+    }
+    else
+    {
+        const float alphac = *alpha;
+
+        for ( i = 0; i < n; ++i )
+        {
+            const float x0c = *x0;
+
+            *y0 += alphac * x0c;
+
+            x0 += incx;
+            y0 += incy;
+        }
+    }
+
 }
 
 // -----------------------------------------------------------------------------
 
-void bli_daxpyv_zen_int10
+BLIS_EXPORT_BLIS void bli_daxpyv_zen_int_10
      (
              conj_t  conjx,
              dim_t   n,
-       const void*   alpha0,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   alpha00,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const double*    alpha = alpha0;
-	const double*    x     = x0;
-	      double*    y     = y0;
 
-	const dim_t      n_elem_per_reg = 4;
+	double *alpha = (double *)alpha00;
+	double *x     = (double *)x00;
+	double *y     = (double *)y00;
 
-	dim_t            i;
+    const dim_t      n_elem_per_reg = 4;
 
-	__m256d          alphav;
-	__m256d          xv[10];
-	__m256d          yv[10];
-	__m256d          zv[10];
+    dim_t            i;
 
-	// If the vector dimension is zero, or if alpha is zero, return early.
-	if ( bli_zero_dim1( n ) || PASTEMAC(d,eq0)( *alpha ) ) return;
+    double* restrict x0 = x;
+    double* restrict y0 = y;
 
-	// Initialize local pointers.
-	const double* restrict xp = x;
-	      double* restrict yp = y;
+    __m256d          alphav;
+    __m256d          xv[4];
+    __m256d          yv[4];
+    __m256d          zv[4];
 
-	if ( incx == 1 && incy == 1 )
-	{
-		// Broadcast the alpha scalar to all elements of a vector register.
-		alphav = _mm256_broadcast_sd( alpha );
+    // If the vector dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim1( n ) || PASTEMAC(d,eq0)( *alpha ) )
+    {
+        return;
+    }
 
-		for ( i = 0; (i + 39) < n; i += 40 )
-		{
-			// 40 elements will be processed per loop; 10 FMAs will run per loop.
-			xv[0] = _mm256_loadu_pd( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_pd( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_pd( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_pd( xp + 3*n_elem_per_reg );
-			xv[4] = _mm256_loadu_pd( xp + 4*n_elem_per_reg );
-			xv[5] = _mm256_loadu_pd( xp + 5*n_elem_per_reg );
-			xv[6] = _mm256_loadu_pd( xp + 6*n_elem_per_reg );
-			xv[7] = _mm256_loadu_pd( xp + 7*n_elem_per_reg );
-			xv[8] = _mm256_loadu_pd( xp + 8*n_elem_per_reg );
-			xv[9] = _mm256_loadu_pd( xp + 9*n_elem_per_reg );
+    // Initialize local pointers.
+    x0 = x;
+    y0 = y;
 
-			yv[0] = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_pd( yp + 3*n_elem_per_reg );
-			yv[4] = _mm256_loadu_pd( yp + 4*n_elem_per_reg );
-			yv[5] = _mm256_loadu_pd( yp + 5*n_elem_per_reg );
-			yv[6] = _mm256_loadu_pd( yp + 6*n_elem_per_reg );
-			yv[7] = _mm256_loadu_pd( yp + 7*n_elem_per_reg );
-			yv[8] = _mm256_loadu_pd( yp + 8*n_elem_per_reg );
-			yv[9] = _mm256_loadu_pd( yp + 9*n_elem_per_reg );
+    if ( incx == 1 && incy == 1 )
+    {
+        // Broadcast the alpha scalar to all elements of a vector register.
+        alphav = _mm256_broadcast_sd( alpha );
 
-			zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_pd( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_pd( xv[3], alphav, yv[3] );
-			zv[4] = _mm256_fmadd_pd( xv[4], alphav, yv[4] );
-			zv[5] = _mm256_fmadd_pd( xv[5], alphav, yv[5] );
-			zv[6] = _mm256_fmadd_pd( xv[6], alphav, yv[6] );
-			zv[7] = _mm256_fmadd_pd( xv[7], alphav, yv[7] );
-			zv[8] = _mm256_fmadd_pd( xv[8], alphav, yv[8] );
-			zv[9] = _mm256_fmadd_pd( xv[9], alphav, yv[9] );
+        for ( i = 0; ( i + 15 ) < n; i += 16 )
+        {
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_pd( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_pd( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_pd( x0 + 3*n_elem_per_reg );
 
-			_mm256_storeu_pd( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_pd( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_pd( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_pd( (yp + 3*n_elem_per_reg), zv[3] );
-			_mm256_storeu_pd( (yp + 4*n_elem_per_reg), zv[4] );
-			_mm256_storeu_pd( (yp + 5*n_elem_per_reg), zv[5] );
-			_mm256_storeu_pd( (yp + 6*n_elem_per_reg), zv[6] );
-			_mm256_storeu_pd( (yp + 7*n_elem_per_reg), zv[7] );
-			_mm256_storeu_pd( (yp + 8*n_elem_per_reg), zv[8] );
-			_mm256_storeu_pd( (yp + 9*n_elem_per_reg), zv[9] );
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
 
-			xp += 10*n_elem_per_reg;
-			yp += 10*n_elem_per_reg;
-		}
+            zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
+            zv[2] = _mm256_fmadd_pd( xv[2], alphav, yv[2] );
+            zv[3] = _mm256_fmadd_pd( xv[3], alphav, yv[3] );
 
-		for ( ; (i + 19) < n; i += 20 )
-		{
-			xv[0] = _mm256_loadu_pd( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_pd( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_pd( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_pd( xp + 3*n_elem_per_reg );
-			xv[4] = _mm256_loadu_pd( xp + 4*n_elem_per_reg );
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), zv[1] );
+            _mm256_storeu_pd( (y0 + 2*n_elem_per_reg), zv[2] );
+            _mm256_storeu_pd( (y0 + 3*n_elem_per_reg), zv[3] );
 
-			yv[0] = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_pd( yp + 3*n_elem_per_reg );
-			yv[4] = _mm256_loadu_pd( yp + 4*n_elem_per_reg );
+            x0 += 4*n_elem_per_reg;
+            y0 += 4*n_elem_per_reg;
+        }
 
-			zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_pd( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_pd( xv[3], alphav, yv[3] );
-			zv[4] = _mm256_fmadd_pd( xv[4], alphav, yv[4] );
+        for ( ; ( i + 7 ) < n; i += 8 )
+        {
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_pd( x0 + 1*n_elem_per_reg );
 
-			_mm256_storeu_pd( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_pd( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_pd( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_pd( (yp + 3*n_elem_per_reg), zv[3] );
-			_mm256_storeu_pd( (yp + 4*n_elem_per_reg), zv[4] );
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
 
-			xp += 5*n_elem_per_reg;
-			yp += 5*n_elem_per_reg;
-		}
+            zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
+            zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
 
-		for ( ; (i + 15) < n; i += 16 )
-		{
-			xv[0] = _mm256_loadu_pd( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_pd( xp + 1*n_elem_per_reg );
-			xv[2] = _mm256_loadu_pd( xp + 2*n_elem_per_reg );
-			xv[3] = _mm256_loadu_pd( xp + 3*n_elem_per_reg );
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), zv[0] );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), zv[1] );
 
-			yv[0] = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-			yv[2] = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
-			yv[3] = _mm256_loadu_pd( yp + 3*n_elem_per_reg );
+            x0 += 2*n_elem_per_reg;
+            y0 += 2*n_elem_per_reg;
+        }
 
-			zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
-			zv[2] = _mm256_fmadd_pd( xv[2], alphav, yv[2] );
-			zv[3] = _mm256_fmadd_pd( xv[3], alphav, yv[3] );
+        for ( ; ( i + 3 ) < n; i += 4 )
+        {
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
 
-			_mm256_storeu_pd( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_pd( (yp + 1*n_elem_per_reg), zv[1] );
-			_mm256_storeu_pd( (yp + 2*n_elem_per_reg), zv[2] );
-			_mm256_storeu_pd( (yp + 3*n_elem_per_reg), zv[3] );
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
 
-			xp += 4*n_elem_per_reg;
-			yp += 4*n_elem_per_reg;
-		}
+            zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
 
-		for ( ; i + 7 < n; i += 8 )
-		{
-			xv[0] = _mm256_loadu_pd( xp + 0*n_elem_per_reg );
-			xv[1] = _mm256_loadu_pd( xp + 1*n_elem_per_reg );
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), zv[0] );
 
-			yv[0] = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-			yv[1] = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
+            x0 += 1*n_elem_per_reg;
+            y0 += 1*n_elem_per_reg;
+        }
 
-			zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
-			zv[1] = _mm256_fmadd_pd( xv[1], alphav, yv[1] );
+        // Issue vzeroupper instruction to clear upper lanes of ymm registers.
+        // This avoids a performance penalty caused by false dependencies when
+        // transitioning from AVX to SSE instructions (which may occur as soon
+        // as the n_left cleanup loop below if BLIS is compiled with
+        // -mfpmath=sse).
+        _mm256_zeroupper();
 
-			_mm256_storeu_pd( (yp + 0*n_elem_per_reg), zv[0] );
-			_mm256_storeu_pd( (yp + 1*n_elem_per_reg), zv[1] );
+        for ( ; i < n; i += 1 )
+        {
+            *y0 += (*alpha) * (*x0);
 
-			xp += 2*n_elem_per_reg;
-			yp += 2*n_elem_per_reg;
-		}
+            y0 += 1;
+            x0 += 1;
+        }
+    }
+    else
+    {
+        const double alphac = *alpha;
 
-		for ( ; i + 3 < n; i += 4 )
-		{
-			xv[0] = _mm256_loadu_pd( xp + 0*n_elem_per_reg );
+        for ( i = 0; i < n; ++i )
+        {
+            const double x0c = *x0;
 
-			yv[0] = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
+            *y0 += alphac * x0c;
 
-			zv[0] = _mm256_fmadd_pd( xv[0], alphav, yv[0] );
-
-			_mm256_storeu_pd( (yp + 0*n_elem_per_reg), zv[0] );
-
-			xp += 1*n_elem_per_reg;
-			yp += 1*n_elem_per_reg;
-		}
-
-		// Issue vzeroupper instruction to clear upper lanes of ymm registers.
-		// This avoids a performance penalty caused by false dependencies when
-		// transitioning from from AVX to SSE instructions (which may occur
-		// as soon as the n_left cleanup loop below if BLIS is compiled with
-		// -mfpmath=sse).
-		_mm256_zeroupper();
-
-		for ( ; i < n; i += 1 )
-		{
-			*yp += (*alpha) * (*xp);
-
-			yp += 1;
-			xp += 1;
-		}
-	}
-	else
-	{
-		const double alphac = *alpha;
-
-		for ( i = 0; i < n; ++i )
-		{
-			const double xpc = *xp;
-
-			*yp += alphac * xpc;
-
-			xp += incx;
-			yp += incy;
-		}
-	}
+            x0 += incx;
+            y0 += incy;
+        }
+    }
 }
 
+// -----------------------------------------------------------------------------
+
+void bli_caxpyv_zen_int_5
+     (
+             conj_t  conjx,
+             dim_t   n,
+       const void*   alpha00,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
+       const cntx_t* cntx
+     )
+{
+	scomplex *alpha = (scomplex *)alpha00;
+	scomplex *x     = (scomplex *)x00;
+	scomplex *y     = (scomplex *)y00;
+
+    const dim_t      n_elem_per_reg = 8;
+
+    dim_t            i;
+
+    float*  restrict x0;
+    float*  restrict y0;
+    float*  restrict alpha0;
+
+    float alphaR, alphaI;
+
+    //scomplex alpha => aR + aI i
+    __m256           alphaRv;            // for broadcast vector aR (real part of alpha)
+    __m256           alphaIv;            // for broadcast vector aI (imaginary part of alpha)
+    __m256           xv[10];
+    __m256           xShufv[10];
+    __m256           yv[10];
+
+    conj_t conjx_use = conjx;
+
+    // If the vector dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim1( n ) || PASTEMAC(c,eq0)( *alpha ) )
+    {
+        return;
+    }
+
+    // Initialize local pointers.
+    x0 = (float*)x;
+    y0 = (float*)y;
+    alpha0 = (float*)alpha;
+
+    alphaR = alpha->real;
+    alphaI = alpha->imag;
+
+    if ( incx == 1 && incy == 1 )
+    {
+        // Broadcast the alpha scalar to all elements of a vector register.
+        if ( !bli_is_conj (conjx) ) // If BLIS_NO_CONJUGATE
+        {
+            alphaRv = _mm256_broadcast_ss( &alphaR );
+
+            alphaIv = _mm256_set_ps(alphaI, -alphaI, alphaI, -alphaI, alphaI, -alphaI, alphaI, -alphaI);
+
+        }
+        else
+        {
+            alphaIv = _mm256_broadcast_ss( &alphaI );
+
+            alphaRv = _mm256_set_ps(-alphaR, alphaR, -alphaR, alphaR, -alphaR, alphaR, -alphaR, alphaR);
+        }
+
+        //----------Scalar algorithm BLIS_NO_CONJUGATE arg-------------
+        // y = alpha*x + y
+        // y = (aR + aIi) * (xR + xIi) + (yR + yIi)
+        // y = aR.xR + aR.xIi + aIi.xR - aIxI + (yR + yIi)
+        // y = aR.xR - aIxI + yR + aR.xIi + xR.aIi + yIi
+        // y = ( aR.xR - aIxI + yR ) + ( aR.xI + aI.xR + yI )i
+
+        // SIMD algorithm
+        // xv  = xR1  xI1  xR2  xI2  xR3  xI3  xR4  xI4
+        // xv' = xI1  xR1  xI2  xR2  xI3  xR3  xI4  xR4 (shuffle xv)
+        // arv = aR   aR   aR   aR   aR   aR   aR   aR
+        // aiv = aI  -aI   aI  -aI   aI  -aI   aI  -aI
+        // yv  = yR1  yI1  yR2  yI2  yR3  yI3  yR4  yI4
+
+
+        //----------Scalar algorithm for BLIS_CONJUGATE arg-------------
+        // y = alpha*conj(x) + y
+        // y = (aR + aIi) * (xR - xIi) + (yR + yIi)
+        // y = aR.xR - aR.xIi + aIi.xR + aIxI + (yR + yIi)
+        // y = aR.xR + aIxI + yR - aR.xIi + xR.aIi + yIi
+        // y = ( aR.xR + aIxI + yR ) + ( -aR.xI + aI.xR + yI )i
+        // y = ( aR.xR + aIxI + yR ) + (aI.xR - aR.xI + yI)i
+
+        // SIMD algorithm
+        // xv  = xR1  xI1  xR2  xI2  xR3  xI3  xR4  xI4
+        // xv' = xI1  xR1  xI2  xR2  xI3  xR3  xI4  xR4
+        // arv = aR  -aR   aR   -aR   aR  -aR   aR  -aR
+        // aiv = aI   aI   aI   aI   aI   aI   aI   aI
+        // yv  = yR1  yI1  yR2  yI2  yR3  yI3  yR4  yI4
+
+        // step 1 :  Shuffle xv vector -> xv'
+        // step 2 : fma yv = arv*xv + yv
+        // step 3 : fma yv = aiv*xv' + yv (old)
+        //              yv = aiv*xv' + arv*xv + yv
+
+        for ( i= 0 ; (i + 19) < n; i += 20 )
+        {
+            // 20 elements will be processed per loop; 10 FMAs will run per loop.
+
+            // alphaRv = aR   aR   aR   aR   aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2  xR3  xI3  xR4  xI4
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_ps( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_ps( x0 + 3*n_elem_per_reg );
+            xv[4] = _mm256_loadu_ps( x0 + 4*n_elem_per_reg );
+
+            // yv      = yR1  yI1  yR2  yI2  yR3  yI3  yR4  yI4
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_ps( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_ps( y0 + 3*n_elem_per_reg );
+            yv[4] = _mm256_loadu_ps( y0 + 4*n_elem_per_reg );
+
+            // xv'     = xI1  xR1  xI2  xR2  xI3  xR3  xI4  xR4
+            xShufv[0] = _mm256_permute_ps( xv[0], 0xB1);
+            xShufv[1] = _mm256_permute_ps( xv[1], 0xB1);
+            xShufv[2] = _mm256_permute_ps( xv[2], 0xB1);
+            xShufv[3] = _mm256_permute_ps( xv[3], 0xB1);
+            xShufv[4] = _mm256_permute_ps( xv[4], 0xB1);
+
+            // alphaIv = -aI   aI  -aI   aI  -aI   aI  -aI  aI
+
+            // yv  = ar*xv + yv
+            //     = aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_ps( xv[0], alphaRv ,yv[0]);
+            yv[1] = _mm256_fmadd_ps( xv[1], alphaRv ,yv[1]);
+            yv[2] = _mm256_fmadd_ps( xv[2], alphaRv ,yv[2]);
+            yv[3] = _mm256_fmadd_ps( xv[3], alphaRv ,yv[3]);
+            yv[4] = _mm256_fmadd_ps( xv[4], alphaRv ,yv[4]);
+
+            // yv =  ai*xv' + yv (old)
+            // yv =  ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_ps( xShufv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_ps( xShufv[1], alphaIv, yv[1]);
+            yv[2] = _mm256_fmadd_ps( xShufv[2], alphaIv, yv[2]);
+            yv[3] = _mm256_fmadd_ps( xShufv[3], alphaIv, yv[3]);
+            yv[4] = _mm256_fmadd_ps( xShufv[4], alphaIv, yv[4]);
+
+            // Store back the results
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), yv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), yv[1] );
+            _mm256_storeu_ps( (y0 + 2*n_elem_per_reg), yv[2] );
+            _mm256_storeu_ps( (y0 + 3*n_elem_per_reg), yv[3] );
+            _mm256_storeu_ps( (y0 + 4*n_elem_per_reg), yv[4] );
+
+            x0 += 5*n_elem_per_reg;
+            y0 += 5*n_elem_per_reg;
+        }
+
+        for ( ; (i + 7) < n; i += 8 )
+        {
+            // alphaRv = aR   aR   aR   aR   aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2  xR3  xI3  xR4  xI4
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_ps( x0 + 1*n_elem_per_reg );
+
+            // yv      = yR1  yI1  yR2  yI2  yR3  yI3  yR4  yI4
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
+
+            // xv'     = xI1  xR1  xI2  xR2  xI3  xR3  xI4  xR4
+            xShufv[0] = _mm256_permute_ps( xv[0], 0xB1);
+            xShufv[1] = _mm256_permute_ps( xv[1], 0xB1);
+
+            // alphaIv = -aI   aI  -aI   aI  -aI   aI  -aI  aI
+
+            // yv  = ar*xv + yv
+            //     = aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_ps( xv[0], alphaRv ,yv[0]);
+            yv[1] = _mm256_fmadd_ps( xv[1], alphaRv ,yv[1]);
+
+            // yv = ai*xv' + yv (old)
+            // yv = ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_ps( xShufv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_ps( xShufv[1], alphaIv, yv[1]);
+
+            // Store back the result
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), yv[0] );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), yv[1] );
+
+            x0 += 2*n_elem_per_reg;
+            y0 += 2*n_elem_per_reg;
+        }
+
+        for ( ; (i + 3) < n; i += 4 )
+        {
+            // alphaRv = aR   aR   aR   aR   aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2  xR3  xI3  xR4  xI4
+            xv[0] = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+
+            // yv      = yR1  yI1  yR2  yI2  yR3  yI3  yR4  yI4
+            yv[0] = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+
+            // xv'     = xI1  xR1  xI2  xR2  xI3  xR3  xI4  xR4
+            xShufv[0] = _mm256_permute_ps( xv[0], 0xB1);
+
+            // alphaIv = -aI   aI  -aI   aI  -aI   aI  -aI  aI
+
+            // yv = ar*xv + yv
+            //    = aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_ps( xv[0], alphaRv ,yv[0]);
+
+            // yv = ai*xv' + yv (old)
+            // yv = ai*xv' + ar*xv + yv
+            //    = aR.xR1 - aI*xI1 + yR1, aR.xI1 + aI.xR1 + yI1
+            yv[0] = _mm256_fmadd_ps( xShufv[0], alphaIv, yv[0]);
+
+            // Store back the result
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), yv[0] );
+
+            x0 += 1*n_elem_per_reg;
+            y0 += 1*n_elem_per_reg;
+        }
+
+        // Issue vzeroupper instruction to clear upper lanes of ymm registers.
+        // This avoids a performance penalty caused by false dependencies when
+        // transitioning from AVX to SSE instructions (which may occur as soon
+        // as the n_left cleanup loop below if BLIS is compiled with
+        // -mfpmath=sse).
+        _mm256_zeroupper();
+
+        /* Residual values are calculated here
+        y0 += (alpha) * (x0); --> BLIS_NO_CONJUGATE
+        y0 += ( aR.xR - aIxI + yR ) + ( aR.xI + aI.xR + yI )i
+
+        y0 += (alpha) * conjx(x0); --> BLIS_CONJUGATE
+        y0 = ( aR.xR + aIxI + yR ) + (aI.xR - aR.xI + yI)i */
+
+        if ( !bli_is_conj(conjx_use) ) //  BLIS_NO_CONJUGATE
+        {
+            for ( ; (i + 0) < n; i += 1 )
+            {
+                // real part: ( aR.xR - aIxI + yR )
+                *y0       += *alpha0 * (*x0) - (*(alpha0 + 1)) * (*(x0+1));
+                // img part: ( aR.xI + aI.xR + yI )
+                *(y0 + 1) += *alpha0 * (*(x0+1)) +  (*(alpha0 + 1)) * (*x0);
+                x0 += 2;
+                y0 += 2;
+            }
+        }
+        else //  BLIS_CONJUGATE
+        {
+            for ( ; (i + 0) < n; i += 1 )
+            {
+                // real part: ( aR.xR + aIxI + yR )
+                *y0       += *alpha0 * (*x0) + (*(alpha0 + 1)) * (*(x0+1));
+                // img part: (  aI.xR - aR.xI + yI )
+                *(y0 + 1) += (*(alpha0 + 1)) * (*x0) - (*alpha0) * (*(x0+1));
+                x0 += 2;
+                y0 += 2;
+            }
+        }
+
+    }
+    else
+    {
+        const float alphar = *alpha0;
+        const float alphai = *(alpha0 + 1);
+
+        if ( !bli_is_conj(conjx_use) )
+        {
+            for ( i = 0; i < n; ++i )
+            {
+                const float x0c = *x0;
+                const float x1c = *( x0+1 );
+
+                *y0         += alphar * x0c - alphai * x1c;
+                *(y0 + 1)   += alphar * x1c + alphai * x0c;
+
+                x0 += incx * 2;
+                y0 += incy * 2;
+            }
+        }
+        else
+        {
+            for ( i = 0; i < n; ++i )
+            {
+                const float x0c = *x0;
+                const float x1c = *( x0+1 );
+
+                *y0         += alphar * x0c + alphai * x1c;
+                *(y0 + 1)   += alphai * x0c - alphar * x1c;
+
+                x0 += incx * 2;
+                y0 += incy * 2;
+            }
+        }
+
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void bli_zaxpyv_zen_int_5
+     (
+             conj_t  conjx,
+             dim_t   n,
+       const void*   alpha00,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
+       const cntx_t* cntx
+     )
+{
+
+	dcomplex *alpha = (dcomplex *)alpha00;
+	dcomplex *x     = (dcomplex *)x00;
+	dcomplex *y     = (dcomplex *)y00;
+
+    // If the vector dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim1( n ) || PASTEMAC(z,eq0)( *alpha ) )
+    {
+         return;
+    }
+
+    dim_t            i = 0;
+
+    // Initialize local pointers.
+    double* x0 = (double*)x;
+    double* y0 = (double*)y;
+
+    double alphaR = alpha->real;
+    double alphaI = alpha->imag;
+
+    if ( incx == 1 && incy == 1 )
+    {
+        const dim_t n_elem_per_reg = 4;
+
+        __m256d alphaRv; // for broadcast vector aR (real part of alpha)
+        __m256d alphaIv; // for broadcast vector aI (imaginary part of alpha)
+        __m256d xv[7]; // Holds the X vector elements
+        __m256d xShufv[5]; // Holds the permuted X vector elements
+        __m256d yv[7]; // Holds the y vector elements
+
+        // Prefetch distance used in the kernel based on number of cycles
+        // In this case, 16 cycles
+        const dim_t distance = 16;
+
+        // Prefetch X vector to the L1 cache
+        // as these elements will be need anyway
+        _mm_prefetch((char const*)x0, _MM_HINT_T1);
+
+        // Broadcast the alpha scalar to all elements of a vector register.
+        if (bli_is_noconj(conjx)) // If BLIS_NO_CONJUGATE
+        {
+            alphaRv = _mm256_broadcast_sd(&alphaR);
+
+            alphaIv[0] = -alphaI;
+            alphaIv[1] = alphaI;
+            alphaIv[2] = -alphaI;
+            alphaIv[3] = alphaI;
+        }
+        else
+        {
+            alphaIv = _mm256_broadcast_sd(&alphaI);
+
+            alphaRv[0] = alphaR;
+            alphaRv[1] = -alphaR;
+            alphaRv[2] = alphaR;
+            alphaRv[3] = -alphaR;
+        }
+
+        // --------Scalar algorithm BLIS_NO_CONJUGATE arg-------------
+        // y = alpha*x + y
+        // y = (aR + aIi) * (xR + xIi) + (yR + yIi)
+        // y = aR.xR + aR.xIi + aIi.xR - aIxI + (yR + yIi)
+        // y = aR.xR - aIxI + yR + aR.xIi + xR.aIi + yIi
+        // y = ( aR.xR - aIxI + yR ) + ( aR.xI + aI.xR + yI )i
+
+        // SIMD algorithm
+        // xv  = xR1  xI1  xR2  xI2
+        // xv' = xI1  xR1  xI2  xR2
+        // arv = aR   aR   aR   aR
+        // aiv = -aI  aI  -aI   aI
+        // yv  = yR1  yI1  yR2  yI2
+
+        // S1 : xv' = xI1  xR1  xI2  xR2 (Shuffle)
+        // S2 : reg0 = (aR.xR1  aR.xI1  aR.xR2  aR.xI2) + yv
+        // S3 : reg1 = (-aI.xI1  aI.xR1 -aI.xI2  aI.xR2) + reg0
+        //----------------------------------------------------------------
+        // Ans : aR.xR1 -aI.xI1 + yR1, aR.xI1 + aI.xR1 + yI1, aR.xR2 -aI.xI2 + yR2, aR.xI2 + aI.xR2 + yI2
+
+        //----------Scalar algorithm for BLIS_CONJUGATE arg-------------
+        // y = alpha*conj(x) + y
+        // y = (aR + aIi) * (xR - xIi) + (yR + yIi)
+        // y = aR.xR - aR.xIi + aIi.xR + aIxI + (yR + yIi)
+        // y = aR.xR + aIxI + yR - aR.xIi + xR.aIi + yIi
+        // y = ( aR.xR + aIxI + yR ) + ( -aR.xI + aI.xR + yI )i
+        // y = ( aR.xR + aIxI + yR ) + (aI.xR - aR.xI + yI)i
+
+        // SIMD algorithm
+        // xv  = xR1  xI1  xR2  xI2
+        // xv' = xI1  xR1  xI2  xR2
+        // arv = aR  -aR   aR   -aR
+        // aiv = aI   aI   aI   aI
+        // yv  = yR1  yI1  yR2  yI2
+
+        // step 1 :  Shuffle xv vector
+        // reg xv : xv' = xI1  xR1  xI2  xR2
+        // step 2 : fma :yv = ar*xv + yv = ar*xv + yv
+        // step 3 : fma :yv = ai*xv' + yv (old)
+        //               yv = ai*xv' + ar*xv + yv
+
+        for (i = 0; (i + 13) < n; i += 14)
+        {
+            // 14 elements will be processed per loop; 14 FMAs will run per loop.
+
+            // alphaRv = aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2
+            xv[0] = _mm256_loadu_pd(x0 + 0 * n_elem_per_reg);
+            xv[1] = _mm256_loadu_pd(x0 + 1 * n_elem_per_reg);
+            xv[2] = _mm256_loadu_pd(x0 + 2 * n_elem_per_reg);
+            xv[3] = _mm256_loadu_pd(x0 + 3 * n_elem_per_reg);
+            xv[4] = _mm256_loadu_pd(x0 + 4 * n_elem_per_reg);
+            xv[5] = _mm256_loadu_pd(x0 + 5 * n_elem_per_reg);
+            xv[6] = _mm256_loadu_pd(x0 + 6 * n_elem_per_reg);
+
+            // yv    =  yR1  yI1  yR2  yI2
+            yv[0] = _mm256_loadu_pd(y0 + 0 * n_elem_per_reg);
+            yv[1] = _mm256_loadu_pd(y0 + 1 * n_elem_per_reg);
+            yv[2] = _mm256_loadu_pd(y0 + 2 * n_elem_per_reg);
+            yv[3] = _mm256_loadu_pd(y0 + 3 * n_elem_per_reg);
+            yv[4] = _mm256_loadu_pd(y0 + 4 * n_elem_per_reg);
+            yv[5] = _mm256_loadu_pd(y0 + 5 * n_elem_per_reg);
+            yv[6] = _mm256_loadu_pd(y0 + 6 * n_elem_per_reg);
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd(xv[0], alphaRv, yv[0]);
+            yv[1] = _mm256_fmadd_pd(xv[1], alphaRv, yv[1]);
+            yv[2] = _mm256_fmadd_pd(xv[2], alphaRv, yv[2]);
+            yv[3] = _mm256_fmadd_pd(xv[3], alphaRv, yv[3]);
+            yv[4] = _mm256_fmadd_pd(xv[4], alphaRv, yv[4]);
+            yv[5] = _mm256_fmadd_pd(xv[5], alphaRv, yv[5]);
+            yv[6] = _mm256_fmadd_pd(xv[6], alphaRv, yv[6]);
+
+            // xv'   =  xI1  xRI  xI2  xR2
+            xv[0] = _mm256_permute_pd(xv[0], 5);
+            xv[1] = _mm256_permute_pd(xv[1], 5);
+            xv[2] = _mm256_permute_pd(xv[2], 5);
+            xv[3] = _mm256_permute_pd(xv[3], 5);
+            xv[4] = _mm256_permute_pd(xv[4], 5);
+            xv[5] = _mm256_permute_pd(xv[5], 5);
+            xv[6] = _mm256_permute_pd(xv[6], 5);
+
+            // Prefetch X and Y vectors to the L1 cache
+            _mm_prefetch((char const*)(x0 + distance), _MM_HINT_T1);
+            _mm_prefetch((char const*)(y0 + distance), _MM_HINT_T1);
+            // alphaIv = -aI   aI  -aI   aI
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd(xv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_pd(xv[1], alphaIv, yv[1]);
+            yv[2] = _mm256_fmadd_pd(xv[2], alphaIv, yv[2]);
+            yv[3] = _mm256_fmadd_pd(xv[3], alphaIv, yv[3]);
+            yv[4] = _mm256_fmadd_pd(xv[4], alphaIv, yv[4]);
+            yv[5] = _mm256_fmadd_pd(xv[5], alphaIv, yv[5]);
+            yv[6] = _mm256_fmadd_pd(xv[6], alphaIv, yv[6]);
+
+            // Store back the result
+            _mm256_storeu_pd((y0 + 0 * n_elem_per_reg), yv[0]);
+            _mm256_storeu_pd((y0 + 1 * n_elem_per_reg), yv[1]);
+            _mm256_storeu_pd((y0 + 2 * n_elem_per_reg), yv[2]);
+            _mm256_storeu_pd((y0 + 3 * n_elem_per_reg), yv[3]);
+            _mm256_storeu_pd((y0 + 4 * n_elem_per_reg), yv[4]);
+            _mm256_storeu_pd((y0 + 5 * n_elem_per_reg), yv[5]);
+            _mm256_storeu_pd((y0 + 6 * n_elem_per_reg), yv[6]);
+
+            x0 += 7 * n_elem_per_reg;
+            y0 += 7 * n_elem_per_reg;
+        }
+
+        for ( ; (i + 9) < n; i += 10 )
+        {
+            // 10 elements will be processed per loop; 10 FMAs will run per loop.
+
+            // alphaRv = aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_pd( x0 + 1*n_elem_per_reg );
+            xv[2] = _mm256_loadu_pd( x0 + 2*n_elem_per_reg );
+            xv[3] = _mm256_loadu_pd( x0 + 3*n_elem_per_reg );
+            xv[4] = _mm256_loadu_pd( x0 + 4*n_elem_per_reg );
+
+            // yv    =  yR1  yI1  yR2  yI2
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            yv[2] = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+            yv[3] = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
+            yv[4] = _mm256_loadu_pd( y0 + 4*n_elem_per_reg );
+
+            // xv'   =  xI1  xRI  xI2  xR2
+            xShufv[0] = _mm256_permute_pd( xv[0], 5);
+            xShufv[1] = _mm256_permute_pd( xv[1], 5);
+            xShufv[2] = _mm256_permute_pd( xv[2], 5);
+            xShufv[3] = _mm256_permute_pd( xv[3], 5);
+            xShufv[4] = _mm256_permute_pd( xv[4], 5);
+
+            // alphaIv = -aI   aI  -aI   aI
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd( xv[0], alphaRv ,yv[0]);
+            yv[1] = _mm256_fmadd_pd( xv[1], alphaRv ,yv[1]);
+            yv[2] = _mm256_fmadd_pd( xv[2], alphaRv ,yv[2]);
+            yv[3] = _mm256_fmadd_pd( xv[3], alphaRv ,yv[3]);
+            yv[4] = _mm256_fmadd_pd( xv[4], alphaRv ,yv[4]);
+
+            // yv =  ai*xv' + yv (old)
+            // yv =  ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_pd( xShufv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_pd( xShufv[1], alphaIv, yv[1]);
+            yv[2] = _mm256_fmadd_pd( xShufv[2], alphaIv, yv[2]);
+            yv[3] = _mm256_fmadd_pd( xShufv[3], alphaIv, yv[3]);
+            yv[4] = _mm256_fmadd_pd( xShufv[4], alphaIv, yv[4]);
+
+            // Store back the result
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0] );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1] );
+            _mm256_storeu_pd( (y0 + 2*n_elem_per_reg), yv[2] );
+            _mm256_storeu_pd( (y0 + 3*n_elem_per_reg), yv[3] );
+            _mm256_storeu_pd( (y0 + 4*n_elem_per_reg), yv[4] );
+
+            x0 += 5*n_elem_per_reg;
+            y0 += 5*n_elem_per_reg;
+        }
+
+        for (; (i + 5) < n; i += 6)
+        {
+            // alphaRv = aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2
+            xv[0] = _mm256_loadu_pd(x0 + 0 * n_elem_per_reg);
+            xv[1] = _mm256_loadu_pd(x0 + 1 * n_elem_per_reg);
+            xv[2] = _mm256_loadu_pd(x0 + 2 * n_elem_per_reg);
+
+            // yv    =  yR1  yI1  yR2  yI2
+            yv[0] = _mm256_loadu_pd(y0 + 0 * n_elem_per_reg);
+            yv[1] = _mm256_loadu_pd(y0 + 1 * n_elem_per_reg);
+            yv[2] = _mm256_loadu_pd(y0 + 2 * n_elem_per_reg);
+
+            // xv'   =  xI1  xRI  xI2  xR2
+            xShufv[0] = _mm256_permute_pd(xv[0], 5);
+            xShufv[1] = _mm256_permute_pd(xv[1], 5);
+            xShufv[2] = _mm256_permute_pd(xv[2], 5);
+
+            // alphaIv = -aI   aI  -aI   aI
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd(xv[0], alphaRv, yv[0]);
+            yv[1] = _mm256_fmadd_pd(xv[1], alphaRv, yv[1]);
+            yv[2] = _mm256_fmadd_pd(xv[2], alphaRv, yv[2]);
+
+            // yv =  ai*xv' + yv (old)
+            // yv =  ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_pd(xShufv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_pd(xShufv[1], alphaIv, yv[1]);
+            yv[2] = _mm256_fmadd_pd(xShufv[2], alphaIv, yv[2]);
+
+            // Store back the result
+            _mm256_storeu_pd((y0 + 0 * n_elem_per_reg), yv[0]);
+            _mm256_storeu_pd((y0 + 1 * n_elem_per_reg), yv[1]);
+            _mm256_storeu_pd((y0 + 2 * n_elem_per_reg), yv[2]);
+
+            x0 += 3 * n_elem_per_reg;
+            y0 += 3 * n_elem_per_reg;
+        }
+
+        for ( ; (i + 3) < n; i += 4 )
+        {
+            // alphaRv = aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
+            xv[1] = _mm256_loadu_pd( x0 + 1*n_elem_per_reg );
+
+            // yv    =  yR1  yI1  yR2  yI2
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1] = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+
+            // xv'   =  xI1  xRI  xI2  xR2
+            xShufv[0] = _mm256_permute_pd( xv[0], 5);
+            xShufv[1] = _mm256_permute_pd( xv[1], 5);
+
+            // alphaIv = -aI   aI  -aI   aI
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd( xv[0], alphaRv ,yv[0]);
+            yv[1] = _mm256_fmadd_pd( xv[1], alphaRv ,yv[1]);
+
+            // yv =  ai*xv' + yv (old)
+            // yv =  ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_pd( xShufv[0], alphaIv, yv[0]);
+            yv[1] = _mm256_fmadd_pd( xShufv[1], alphaIv, yv[1]);
+
+            // Store back the result
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0] );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1] );
+
+            x0 += 2*n_elem_per_reg;
+            y0 += 2*n_elem_per_reg;
+        }
+
+        for (  ; (i + 1) < n; i += 2 )
+        {
+            // alphaRv = aR   aR   aR   aR
+            // xv      = xR1  xI1  xR2  xI2
+            xv[0] = _mm256_loadu_pd( x0 + 0*n_elem_per_reg );
+
+            // yv    =  yR1  yI1  yR2  yI2
+            yv[0] = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+
+            // xv'   =  xI1  xRI  xI2  xR2
+            xShufv[0] = _mm256_permute_pd( xv[0], 5);
+
+            // alphaIv = -aI   aI  -aI   aI
+
+            // yv  =  ar*xv + yv
+            //     =  aR.xR1 + yR1, aR.xI1 + yI1, aR.xR2 + yR2, aR.xI2 + yI2, ...
+            yv[0] = _mm256_fmadd_pd( xv[0], alphaRv ,yv[0]);
+
+            // yv =  ai*xv' + yv (old)
+            // yv =  ai*xv' + ar*xv + yv
+            //    = -aI*xI1 + aR.xR1 + yR1, aI.xR1 + aR.xI1 + yI1, .........
+            yv[0] = _mm256_fmadd_pd( xShufv[0], alphaIv, yv[0]);
+
+            // Store back the result
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0] );
+
+            x0 += 1*n_elem_per_reg;
+            y0 += 1*n_elem_per_reg;
+        }
+
+        // Issue vzeroupper instruction to clear upper lanes of ymm registers.
+        // This avoids a performance penalty caused by false dependencies when
+        // transitioning from AVX to SSE instructions (which may occur as soon
+        // as the n_left cleanup loop below if BLIS is compiled with
+        // -mfpmath=sse).
+        _mm256_zeroupper();
+    }
+
+    __m128d alpha_r, alpha_i, x_vec, y_vec;
+
+    // Broadcast the alpha scalar to all elements of a vector register.
+    if (bli_is_noconj(conjx)) // If BLIS_NO_CONJUGATE
+    {
+        alpha_r = _mm_set1_pd(alphaR);
+
+        alpha_i[0] = -alphaI;
+        alpha_i[1] = alphaI;
+    }
+    else
+    {
+        alpha_i = _mm_set1_pd(alphaI);
+
+        alpha_r[0] = alphaR;
+        alpha_r[1] = -alphaR;
+    }
+
+    /* This loop has two functions:
+        1. Acts as the the fringe case when incx == 1 and incy == 1
+        2. Performs the complete computation when incx != 1 or incy != 1
+    */
+    for (; i < n; ++i)
+    {
+
+        x_vec = _mm_loadu_pd(x0);
+        y_vec = _mm_loadu_pd(y0);
+
+        y_vec = _mm_fmadd_pd(x_vec, alpha_r, y_vec);
+        x_vec = _mm_permute_pd(x_vec, 0b01);
+        y_vec = _mm_fmadd_pd(x_vec, alpha_i, y_vec);
+
+        _mm_storeu_pd(y0, y_vec);
+
+        x0 += incx * 2;
+        y0 += incy * 2;
+    }
+
+}

--- a/kernels/zen/1f/bli_axpyf_zen_int_4.c
+++ b/kernels/zen/1f/bli_axpyf_zen_int_4.c
@@ -65,10 +65,10 @@ void bli_caxpyf_zen_int_4
        const cntx_t* cntx
      )
 {
-	const scomplex* restrict alpha = alpha0;
-	const scomplex* restrict a     = a0;
-	const scomplex* restrict x     = x0;
-	      scomplex* restrict y     = y0;
+	const scomplex* restrict alpha = (scomplex *)alpha0;
+	scomplex* restrict a     = (scomplex *)a0;
+	scomplex* restrict x     = (scomplex *)x0;
+	scomplex* restrict y     = (scomplex *)y0;
 
     inc_t fuse_fac = 4;
     inc_t i;
@@ -313,9 +313,9 @@ void bli_zaxpyf_zen_int_4
      )
 {
 	const dcomplex* restrict alpha = (dcomplex *)alpha0;
-	const dcomplex* restrict a     = (dcomplex *)a00;
-	const dcomplex* restrict x     = (dcomplex *)x00;
-	      dcomplex* restrict y     = (dcomplex *)y00;
+	dcomplex* restrict a     = (dcomplex *)a00;
+	dcomplex* restrict x     = (dcomplex *)x00;
+	dcomplex* restrict y     = (dcomplex *)y00;
 
     dim_t fuse_fac = 4;
     // If either dimension is zero, or if alpha is zero, return early.

--- a/kernels/zen/1f/bli_axpyf_zen_int_4.c
+++ b/kernels/zen/1f/bli_axpyf_zen_int_4.c
@@ -4,7 +4,7 @@
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
-   Copyright (C) 2021-2022, Advanced Micro Devices, Inc. All rights reserved.
+   Copyright (C) 2022 - 2025, Advanced Micro Devices, Inc. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are
@@ -35,6 +35,22 @@
 #include "immintrin.h"
 #include "blis.h"
 
+/* Union data structure to access AVX registers
+   One 256-bit AVX register holds 8 SP elements. */
+typedef union
+{
+    __m256  v;
+    float   f[8] __attribute__((aligned(64)));
+} v8sf_t;
+
+/* Union data structure to access AVX registers
+*  One 256-bit AVX register holds 4 DP elements. */
+typedef union
+{
+    __m256d v;
+    double  d[4] __attribute__((aligned(64)));
+} v4df_t;
+
 
 void bli_caxpyf_zen_int_4
      (
@@ -59,7 +75,7 @@ void bli_caxpyf_zen_int_4
 
     __m256 ymm0, ymm1, ymm2, ymm3;
     __m256 ymm4, ymm5, ymm6, ymm7;
-    __m256 ymm8,       ymm10;
+    __m256 ymm8, ymm10;
     __m256 ymm12, ymm13;
 
     float* ap[4];
@@ -280,4 +296,537 @@ void bli_caxpyf_zen_int_4
             yp += incy;
         }
     }
+}
+
+
+void bli_zaxpyf_zen_int_4
+     (
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b_n,
+       const void*   alpha0,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
+       const cntx_t* cntx
+     )
+{
+	const dcomplex* restrict alpha = (dcomplex *)alpha0;
+	const dcomplex* restrict a     = (dcomplex *)a00;
+	const dcomplex* restrict x     = (dcomplex *)x00;
+	      dcomplex* restrict y     = (dcomplex *)y00;
+
+    dim_t fuse_fac = 4;
+    // If either dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim2( m, b_n ) || bli_zeq0( *alpha ) ) return;
+
+    // If b_n is not equal to the fusing factor, then perform the entire
+    // operation as a loop over axpyv.
+    if (b_n != fuse_fac)
+    {
+        __m128d x_vec, alpha_real, alpha_imag, temp[2];
+
+        alpha_real = _mm_set1_pd(((*alpha).real));
+        alpha_imag = _mm_set1_pd(((*alpha).imag));
+
+        for (dim_t i = 0; i < b_n; ++i)
+        {
+            dcomplex *a1 = a + (0) * inca + (i)*lda;
+            dcomplex *chi1 = x + (i)*incx;
+            dcomplex *y1 = y + (0) * incy;
+            dcomplex alpha_chi1;
+
+            // Vectorization of scaling X by alpha
+            x_vec = _mm_loadu_pd((double *)chi1);
+
+            if (bli_is_conj(conjx))
+            {
+                __m128d identity;
+
+                identity = _mm_setr_pd(1, -1);
+
+                x_vec = _mm_mul_pd(x_vec, identity);
+            }
+
+            temp[0] = _mm_mul_pd(x_vec, alpha_real);
+            temp[1] = _mm_mul_pd(x_vec, alpha_imag);
+
+            temp[1] = _mm_permute_pd(temp[1], 0b01);
+
+            temp[0] = _mm_addsub_pd(temp[0], temp[1]);
+
+            _mm_storeu_pd((double *)&alpha_chi1, temp[0]);
+
+            bli_zaxpyv_zen_int_5
+            (
+                conja,
+                m,
+                &alpha_chi1,
+                a1, inca,
+                y1, incy,
+                cntx
+            );
+        }
+
+        return;
+    }
+
+    // A prefetch distance used inside the main loop
+    const dim_t distance = 32;
+
+    dcomplex chi0 = *(x + 0 * incx);
+    dcomplex chi1 = *(x + 1 * incx);
+    dcomplex chi2 = *(x + 2 * incx);
+    dcomplex chi3 = *(x + 3 * incx);
+
+    /* Alpha scaling of X can be vectorized
+       irrespective of the incx  and should
+       be avoided when alpha is 1*/
+    __m128d x_vec[8], alpha_real, alpha_imag, temp[8];
+
+    x_vec[0] = _mm_loadu_pd((double *)&chi0);
+    x_vec[1] = _mm_loadu_pd((double *)&chi1);
+    x_vec[2] = _mm_loadu_pd((double *)&chi2);
+    x_vec[3] = _mm_loadu_pd((double *)&chi3);
+
+    if (bli_is_conj(conjx))
+    {
+        __m128d identity;
+
+        identity = _mm_setr_pd(1, -1);
+
+        x_vec[0] = _mm_mul_pd(x_vec[0], identity);
+        x_vec[1] = _mm_mul_pd(x_vec[1], identity);
+        x_vec[2] = _mm_mul_pd(x_vec[2], identity);
+        x_vec[3] = _mm_mul_pd(x_vec[3], identity);
+    }
+
+    if (!(bli_zeq1(*alpha)))
+    {
+        alpha_real = _mm_set1_pd(((*alpha).real));
+        alpha_imag = _mm_set1_pd(((*alpha).imag));
+
+        temp[0] = _mm_mul_pd(x_vec[0], alpha_real);
+        temp[1] = _mm_mul_pd(x_vec[0], alpha_imag);
+        temp[2] = _mm_mul_pd(x_vec[1], alpha_real);
+        temp[3] = _mm_mul_pd(x_vec[1], alpha_imag);
+        temp[4] = _mm_mul_pd(x_vec[2], alpha_real);
+        temp[5] = _mm_mul_pd(x_vec[2], alpha_imag);
+        temp[6] = _mm_mul_pd(x_vec[3], alpha_real);
+        temp[7] = _mm_mul_pd(x_vec[3], alpha_imag);
+
+        temp[1] = _mm_permute_pd(temp[1], 0b01);
+        temp[3] = _mm_permute_pd(temp[3], 0b01);
+        temp[5] = _mm_permute_pd(temp[5], 0b01);
+        temp[7] = _mm_permute_pd(temp[7], 0b01);
+
+        temp[0] = _mm_addsub_pd(temp[0], temp[1]);
+        temp[2] = _mm_addsub_pd(temp[2], temp[3]);
+        temp[4] = _mm_addsub_pd(temp[4], temp[5]);
+        temp[6] = _mm_addsub_pd(temp[6], temp[7]);
+
+        _mm_storeu_pd((double *)&chi0, temp[0]);
+        _mm_storeu_pd((double *)&chi1, temp[2]);
+        _mm_storeu_pd((double *)&chi2, temp[4]);
+        _mm_storeu_pd((double *)&chi3, temp[6]);
+    }
+    else
+    {
+        _mm_storeu_pd((double *)&chi0, x_vec[0]);
+        _mm_storeu_pd((double *)&chi1, x_vec[1]);
+        _mm_storeu_pd((double *)&chi2, x_vec[2]);
+        _mm_storeu_pd((double *)&chi3, x_vec[3]);
+    }
+
+    dim_t i = 0;
+
+    double *a_ptr[4];
+    double *y0 = (double *)y;
+
+    a_ptr[0] = (double *)a;
+    a_ptr[1] = (double *)a + 2 * lda;
+    a_ptr[2] = a_ptr[1] + 2 * lda;
+    a_ptr[3] = a_ptr[2] + 2 * lda;
+
+
+    // Prefetching the elements of A to the L1 cache.
+    // These will be used even if SSE instructions are used
+    _mm_prefetch((char const*)(a_ptr[0]), _MM_HINT_T1);
+    _mm_prefetch((char const*)(a_ptr[1]), _MM_HINT_T1);
+    _mm_prefetch((char const*)(a_ptr[2]), _MM_HINT_T1);
+    _mm_prefetch((char const*)(a_ptr[3]), _MM_HINT_T1);
+
+    if (inca == 1 && incy == 1)
+    {
+
+        v4df_t ymm0, ymm1, ymm2, ymm3;
+        v4df_t ymm4, ymm5, ymm6, ymm7;
+        v4df_t ymm8, ymm10;
+        v4df_t ymm12, ymm13, ymm14, ymm15;
+
+        // broadcast real & imag parts of 4 elements of x
+        ymm0.v = _mm256_broadcast_sd(&chi0.real); // real part of x0
+        ymm1.v = _mm256_broadcast_sd(&chi0.imag); // imag part of x0
+        ymm2.v = _mm256_broadcast_sd(&chi1.real); // real part of x1
+        ymm3.v = _mm256_broadcast_sd(&chi1.imag); // imag part of x1
+        ymm4.v = _mm256_broadcast_sd(&chi2.real); // real part of x2
+        ymm5.v = _mm256_broadcast_sd(&chi2.imag); // imag part of x2
+        ymm6.v = _mm256_broadcast_sd(&chi3.real); // real part of x3
+        ymm7.v = _mm256_broadcast_sd(&chi3.imag); // imag part of x3
+
+        if (bli_is_noconj(conja))
+        {
+
+            for (; (i + 3) < m; i += 4)
+            {
+                // load first two columns of A
+                ymm8.v = _mm256_loadu_pd(a_ptr[0]);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1]); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2]);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3]);
+
+                // Multiply the loaded columns of A by X
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                _mm_prefetch((char const*)(a_ptr[0] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[1] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[2] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[3] + distance), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                _mm_prefetch((char const*)(y0 + distance), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0);
+
+                // Permute and reduce the complex and real parts
+                ymm13.v = _mm256_permute_pd(ymm13.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm12.v, ymm13.v);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0), ymm12.v);
+
+                // load first two columns of A
+                ymm8.v = _mm256_loadu_pd(a_ptr[0] + 4);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1] + 4); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2] + 4);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3] + 4);
+
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                _mm_prefetch((char const*)(a_ptr[0] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[1] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[2] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[3] + distance * 2), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                _mm_prefetch((char const*)(y0 + distance * 2), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0 + 4);
+
+                ymm13.v = _mm256_permute_pd(ymm13.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm12.v, ymm13.v);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0 + 4), ymm12.v);
+
+                y0 += 8;
+                a_ptr[0] += 8;
+                a_ptr[1] += 8;
+                a_ptr[2] += 8;
+                a_ptr[3] += 8;
+            }
+
+            for (; (i + 1) < m; i += 2)
+            {
+                // load first two columns of A
+                ymm8.v = _mm256_loadu_pd(a_ptr[0]);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1]); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2]);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3]);
+
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0);
+
+                ymm13.v = _mm256_permute_pd(ymm13.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm12.v, ymm13.v);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0), ymm12.v);
+
+                y0 += 4;
+                a_ptr[0] += 4;
+                a_ptr[1] += 4;
+                a_ptr[2] += 4;
+                a_ptr[3] += 4;
+            }
+        }
+        else
+        {
+
+            for (; (i + 3) < m; i += 4)
+            {
+                // load first two columns of A
+                ymm8.v = _mm256_loadu_pd(a_ptr[0]);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1]); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2]);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3]);
+
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                _mm_prefetch((char const*)(a_ptr[0] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[1] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[2] + distance), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[3] + distance), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                _mm_prefetch((char const*)(y0 + distance), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0);
+
+                ymm12.v = _mm256_permute_pd(ymm12.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm13.v, ymm12.v);
+                ymm8.v = _mm256_permute_pd(ymm8.v, 5);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0), ymm12.v);
+
+                ymm8.v = _mm256_loadu_pd(a_ptr[0] + 4);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1] + 4); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2] + 4);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3] + 4);
+
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                _mm_prefetch((char const*)(a_ptr[0] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[1] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[2] + distance * 2), _MM_HINT_T1);
+                _mm_prefetch((char const*)(a_ptr[3] + distance * 2), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                _mm_prefetch((char const*)(y0 + distance * 2), _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0 + 4);
+
+                ymm12.v = _mm256_permute_pd(ymm12.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm13.v, ymm12.v);
+                ymm8.v = _mm256_permute_pd(ymm8.v, 5);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0 + 4), ymm12.v);
+
+                y0 += 8;
+                a_ptr[0] += 8;
+                a_ptr[1] += 8;
+                a_ptr[2] += 8;
+                a_ptr[3] += 8;
+            }
+
+            for (; (i + 1) < m; i += 2)
+            {
+                // load first two columns of A
+                ymm8.v = _mm256_loadu_pd(a_ptr[0]);  // 2 complex values from a0
+                ymm10.v = _mm256_loadu_pd(a_ptr[1]); // 2 complex values from a0
+                // load 3rd and 4th columns of A
+                ymm14.v = _mm256_loadu_pd(a_ptr[2]);
+                ymm15.v = _mm256_loadu_pd(a_ptr[3]);
+
+                ymm12.v = _mm256_mul_pd(ymm8.v, ymm0.v);
+                ymm13.v = _mm256_mul_pd(ymm8.v, ymm1.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm10.v, ymm2.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm10.v, ymm3.v, ymm13.v);
+
+                //_mm_prefetch(y0, _MM_HINT_T1);
+
+                ymm12.v = _mm256_fmadd_pd(ymm14.v, ymm4.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm14.v, ymm5.v, ymm13.v);
+
+                ymm12.v = _mm256_fmadd_pd(ymm15.v, ymm6.v, ymm12.v);
+                ymm13.v = _mm256_fmadd_pd(ymm15.v, ymm7.v, ymm13.v);
+
+                // load Y vector
+                ymm10.v = _mm256_loadu_pd(y0);
+
+                ymm12.v = _mm256_permute_pd(ymm12.v, 5);
+                ymm8.v = _mm256_addsub_pd(ymm13.v, ymm12.v);
+                ymm8.v = _mm256_permute_pd(ymm8.v, 5);
+
+                ymm12.v = _mm256_add_pd(ymm8.v, ymm10.v);
+
+                _mm256_storeu_pd((double *)(y0), ymm12.v);
+
+                y0 += 4;
+                a_ptr[0] += 4;
+                a_ptr[1] += 4;
+                a_ptr[2] += 4;
+                a_ptr[3] += 4;
+            }
+        }
+    }
+
+    // Issue vzeroupper instruction to clear upper lanes of ymm registers.
+    // This avoids a performance penalty caused by false dependencies when
+    // transitioning from AVX to SSE instructions (which may occur later,
+    // especially if BLIS is compiled with -mfpmath=sse).
+    _mm256_zeroupper();
+
+    __m128d a_vec[4], y_vec, inter[2];
+
+    // broadcast real & imag parts of 4 elements of x
+    x_vec[0] = _mm_set1_pd(chi0.real); // real part of x0
+    x_vec[1] = _mm_set1_pd(chi0.imag); // imag part of x0
+    x_vec[2] = _mm_set1_pd(chi1.real); // real part of x1
+    x_vec[3] = _mm_set1_pd(chi1.imag); // imag part of x1
+    x_vec[4] = _mm_set1_pd(chi2.real); // real part of x2
+    x_vec[5] = _mm_set1_pd(chi2.imag); // imag part of x2
+    x_vec[6] = _mm_set1_pd(chi3.real); // real part of x3
+    x_vec[7] = _mm_set1_pd(chi3.imag); // imag part of x3
+
+    if (bli_is_noconj(conja))
+    {
+        for (; i < m; i++)
+        {
+            // load first two columns of A
+            a_vec[0] = _mm_loadu_pd(a_ptr[0]); // 2 complex values from a0
+            a_vec[1] = _mm_loadu_pd(a_ptr[1]); // 2 complex values from a0
+            a_vec[2] = _mm_loadu_pd(a_ptr[2]); // 2 complex values from a0
+            a_vec[3] = _mm_loadu_pd(a_ptr[3]); // 2 complex values from a0
+
+            inter[0] = _mm_mul_pd(a_vec[0], x_vec[0]);
+            inter[1] = _mm_mul_pd(a_vec[0], x_vec[1]);
+
+            inter[0] = _mm_fmadd_pd(a_vec[1], x_vec[2], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[1], x_vec[3], inter[1]);
+
+            //_mm_prefetch(y0, _MM_HINT_T1);
+
+            inter[0] = _mm_fmadd_pd(a_vec[2], x_vec[4], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[2], x_vec[5], inter[1]);
+
+            inter[0] = _mm_fmadd_pd(a_vec[3], x_vec[6], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[3], x_vec[7], inter[1]);
+
+            inter[1] = _mm_permute_pd(inter[1], 0b01);
+            inter[0] = _mm_addsub_pd(inter[0], inter[1]);
+
+            // load Y vector
+            y_vec = _mm_loadu_pd(y0);
+
+            y_vec = _mm_add_pd(y_vec, inter[0]);
+
+            _mm_storeu_pd((double *)(y0), y_vec);
+
+            y0 += 2 * incy;
+            a_ptr[0] += 2 * inca;
+            a_ptr[1] += 2 * inca;
+            a_ptr[2] += 2 * inca;
+            a_ptr[3] += 2 * inca;
+        }
+    }
+    else
+    {
+        for (; i < m; i++)
+        {
+            // load first two columns of A
+            a_vec[0] = _mm_loadu_pd(a_ptr[0]); // 2 complex values from a0
+            a_vec[1] = _mm_loadu_pd(a_ptr[1]); // 2 complex values from a0
+                                               // load 3rd and 4th columns of A
+            a_vec[2] = _mm_loadu_pd(a_ptr[2]); // 2 complex values from a0
+            a_vec[3] = _mm_loadu_pd(a_ptr[3]); // 2 complex values from a0
+
+            inter[0] = _mm_mul_pd(a_vec[0], x_vec[0]);
+            inter[1] = _mm_mul_pd(a_vec[0], x_vec[1]);
+
+            inter[0] = _mm_fmadd_pd(a_vec[1], x_vec[2], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[1], x_vec[3], inter[1]);
+
+            // load Y vector
+            y_vec = _mm_loadu_pd(y0);
+
+            inter[0] = _mm_fmadd_pd(a_vec[2], x_vec[4], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[2], x_vec[5], inter[1]);
+
+            inter[0] = _mm_fmadd_pd(a_vec[3], x_vec[6], inter[0]);
+            inter[1] = _mm_fmadd_pd(a_vec[3], x_vec[7], inter[1]);
+
+            inter[0] = _mm_permute_pd(inter[0], 0b01);
+            inter[0] = _mm_addsub_pd(inter[1], inter[0]);
+            inter[0] = _mm_permute_pd(inter[0], 0b01);
+
+            y_vec = _mm_add_pd(y_vec, inter[0]);
+
+            _mm_storeu_pd((double *)(y0), y_vec);
+
+            y0 += 2 * incy;
+            a_ptr[0] += 2 * inca;
+            a_ptr[1] += 2 * inca;
+            a_ptr[2] += 2 * inca;
+            a_ptr[3] += 2 * inca;
+        }
+    }
+
+    // vzeroupper is added by the compiler at the end of the kernel
 }

--- a/kernels/zen/1f/bli_axpyf_zen_int_5.c
+++ b/kernels/zen/1f/bli_axpyf_zen_int_5.c
@@ -4,7 +4,7 @@
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
-   Copyright (C) 2020 - 2022, Advanced Micro Devices, Inc. All rights reserved.
+   Copyright (C) 2020 - 2023, Advanced Micro Devices, Inc. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are
@@ -66,23 +66,30 @@ void bli_saxpyf_zen_int_5
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const float* restrict alpha = alpha0;
-	const float* restrict a     = a0;
-	const float* restrict x     = x0;
-	      float* restrict y     = y0;
+    float *alpha = (float *)alpha0;
+    float *a = (float *)a00;
+    float *x = (float *)x00;
+    float *y = (float *)y00;
 
     const dim_t      fuse_fac       = 5;
-
     const dim_t      n_elem_per_reg = 8;
     const dim_t      n_iter_unroll  = 2;
 
     dim_t            i;
+
+    float* restrict a0;
+    float* restrict a1;
+    float* restrict a2;
+    float* restrict a3;
+    float* restrict a4;
+
+    float* restrict y0;
 
     v8sf_t           chi0v, chi1v, chi2v, chi3v;
     v8sf_t           chi4v;
@@ -106,15 +113,14 @@ void bli_saxpyf_zen_int_5
     if ( b_n != fuse_fac )
     {
         if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
-
         axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_FLOAT, BLIS_AXPYV_KER, cntx );
 
         for ( i = 0; i < b_n; ++i )
         {
-            const float* restrict ap1   = a + (0  )*inca + (i  )*lda;
-            const float* restrict chi1 = x + (i  )*incx;
-                  float* restrict y1   = y + (0  )*incy;
-                  float           alpha_chi1;
+            float* a1   = a + (0  )*inca + (i  )*lda;
+            float* chi1 = x + (i  )*incx;
+            float* y1   = y + (0  )*incy;
+            float  alpha_chi1;
 
             bli_scopycjs( conjx, *chi1, alpha_chi1 );
             bli_sscals( *alpha, alpha_chi1 );
@@ -124,7 +130,7 @@ void bli_saxpyf_zen_int_5
               conja,
               m,
               &alpha_chi1,
-              ap1, inca,
+              a1, inca,
               y1, incy,
               cntx
             );
@@ -135,18 +141,18 @@ void bli_saxpyf_zen_int_5
 
     // At this point, we know that b_n is exactly equal to the fusing factor.
 
-    const float* restrict ap0   = a + 0*lda;
-    const float* restrict ap1   = a + 1*lda;
-    const float* restrict ap2   = a + 2*lda;
-    const float* restrict ap3   = a + 3*lda;
-    const float* restrict ap4   = a + 4*lda;
-          float*          yp   = y;
+    a0   = a + 0*lda;
+    a1   = a + 1*lda;
+    a2   = a + 2*lda;
+    a3   = a + 3*lda;
+    a4   = a + 4*lda;
+    y0   = y;
 
-    chi0 = *( x + 0*incx );
-    chi1 = *( x + 1*incx );
-    chi2 = *( x + 2*incx );
-    chi3 = *( x + 3*incx );
-    chi4 = *( x + 4*incx );
+    chi0 = *( (float *)x + 0*incx );
+    chi1 = *( (float *)x + 1*incx );
+    chi2 = *( (float *)x + 2*incx );
+    chi3 = *( (float *)x + 3*incx );
+    chi4 = *( (float *)x + 4*incx );
 
 
     // Scale each chi scalar by alpha.
@@ -170,23 +176,23 @@ void bli_saxpyf_zen_int_5
         for ( i = 0; (i + 15) < m; i += 16 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_ps( yp + 1*n_elem_per_reg );
+            y0v.v = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_ps( y0 + 1*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_ps( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_ps( ap0 + 1*n_elem_per_reg );
+            a00v.v = _mm256_loadu_ps( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_ps( a0 + 1*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_ps( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_ps( ap1 + 1*n_elem_per_reg );
+            a01v.v = _mm256_loadu_ps( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_ps( a1 + 1*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_ps( ap2 + 0*n_elem_per_reg );
-            a12v.v = _mm256_loadu_ps( ap2 + 1*n_elem_per_reg );
+            a02v.v = _mm256_loadu_ps( a2 + 0*n_elem_per_reg );
+            a12v.v = _mm256_loadu_ps( a2 + 1*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_ps( ap3 + 0*n_elem_per_reg );
-            a13v.v = _mm256_loadu_ps( ap3 + 1*n_elem_per_reg );
+            a03v.v = _mm256_loadu_ps( a3 + 0*n_elem_per_reg );
+            a13v.v = _mm256_loadu_ps( a3 + 1*n_elem_per_reg );
 
-            a04v.v = _mm256_loadu_ps( ap4 + 0*n_elem_per_reg );
-            a14v.v = _mm256_loadu_ps( ap4 + 1*n_elem_per_reg );
+            a04v.v = _mm256_loadu_ps( a4 + 0*n_elem_per_reg );
+            a14v.v = _mm256_loadu_ps( a4 + 1*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_ps( a00v.v, chi0v.v, y0v.v );
@@ -206,27 +212,27 @@ void bli_saxpyf_zen_int_5
 
 
             // Store the output.
-            _mm256_storeu_ps( (yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_ps( (yp + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_ps( (y0 + 1*n_elem_per_reg), y1v.v );
 
-            yp += n_iter_unroll * n_elem_per_reg;
-            ap0 += n_iter_unroll * n_elem_per_reg;
-            ap1 += n_iter_unroll * n_elem_per_reg;
-            ap2 += n_iter_unroll * n_elem_per_reg;
-            ap3 += n_iter_unroll * n_elem_per_reg;
-            ap4 += n_iter_unroll * n_elem_per_reg;
+            y0 += n_iter_unroll * n_elem_per_reg;
+            a0 += n_iter_unroll * n_elem_per_reg;
+            a1 += n_iter_unroll * n_elem_per_reg;
+            a2 += n_iter_unroll * n_elem_per_reg;
+            a3 += n_iter_unroll * n_elem_per_reg;
+            a4 += n_iter_unroll * n_elem_per_reg;
         }
 
         for( ; (i + 7) < m; i += 8 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_ps( yp + 0*n_elem_per_reg );
+            y0v.v = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_ps( ap0 + 0*n_elem_per_reg );
-            a01v.v = _mm256_loadu_ps( ap1 + 0*n_elem_per_reg );
-            a02v.v = _mm256_loadu_ps( ap2 + 0*n_elem_per_reg );
-            a03v.v = _mm256_loadu_ps( ap3 + 0*n_elem_per_reg );
-            a04v.v = _mm256_loadu_ps( ap4 + 0*n_elem_per_reg );
+            a00v.v = _mm256_loadu_ps( a0 + 0*n_elem_per_reg );
+            a01v.v = _mm256_loadu_ps( a1 + 0*n_elem_per_reg );
+            a02v.v = _mm256_loadu_ps( a2 + 0*n_elem_per_reg );
+            a03v.v = _mm256_loadu_ps( a3 + 0*n_elem_per_reg );
+            a04v.v = _mm256_loadu_ps( a4 + 0*n_elem_per_reg );
 
 
             // perform : y += alpha * x;
@@ -237,26 +243,26 @@ void bli_saxpyf_zen_int_5
             y0v.v = _mm256_fmadd_ps( a04v.v, chi4v.v, y0v.v );
 
             // Store the output.
-            _mm256_storeu_ps( (yp + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_ps( (y0 + 0*n_elem_per_reg), y0v.v );
 
-            yp += n_elem_per_reg;
-            ap0 += n_elem_per_reg;
-            ap1 += n_elem_per_reg;
-            ap2 += n_elem_per_reg;
-            ap3 += n_elem_per_reg;
-            ap4 += n_elem_per_reg;
+            y0 += n_elem_per_reg;
+            a0 += n_elem_per_reg;
+            a1 += n_elem_per_reg;
+            a2 += n_elem_per_reg;
+            a3 += n_elem_per_reg;
+            a4 += n_elem_per_reg;
         }
 
         // If there are leftover iterations, perform them with scalar code.
         for ( ; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const float a0c = *ap0;
-            const float a1c = *ap1;
-            const float a2c = *ap2;
-            const float a3c = *ap3;
-            const float a4c = *ap4;
+            const float a0c = *a0;
+            const float a1c = *a1;
+            const float a2c = *a2;
+            const float a3c = *a3;
+            const float a4c = *a4;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
@@ -264,27 +270,27 @@ void bli_saxpyf_zen_int_5
             y0c += chi3 * a3c;
             y0c += chi4 * a4c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += 1;
-            ap1 += 1;
-            ap2 += 1;
-            ap3 += 1;
-            ap4 += 1;
-            yp += 1;
+            a0 += 1;
+            a1 += 1;
+            a2 += 1;
+            a3 += 1;
+            a4 += 1;
+            y0 += 1;
         }
     }
     else
     {
         for ( i = 0; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const float a0c = *ap0;
-            const float a1c = *ap1;
-            const float a2c = *ap2;
-            const float a3c = *ap3;
-            const float a4c = *ap4;
+            const float a0c = *a0;
+            const float a1c = *a1;
+            const float a2c = *a2;
+            const float a3c = *a3;
+            const float a4c = *a4;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
@@ -292,14 +298,14 @@ void bli_saxpyf_zen_int_5
             y0c += chi3 * a3c;
             y0c += chi4 * a4c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += inca;
-            ap1 += inca;
-            ap2 += inca;
-            ap3 += inca;
-            ap4 += inca;
-            yp += incy;
+            a0 += inca;
+            a1 += inca;
+            a2 += inca;
+            a3 += inca;
+            a4 += inca;
+            y0 += incy;
         }
 
     }
@@ -315,37 +321,29 @@ void bli_daxpyf_zen_int_5
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const double* restrict alpha = alpha0;
-	const double* restrict a     = a0;
-	const double* restrict x     = x0;
-	      double* restrict y     = y0;
+    double *alpha = (double *)alpha0;
+    double *a = (double *)a00;
+    double *x = (double *)x00;
+    double *y = (double *)y00;
 
     const dim_t      fuse_fac       = 5;
-
     const dim_t      n_elem_per_reg = 4;
-    const dim_t      n_iter_unroll  = 2;
 
     dim_t            i;
 
-    v4df_t           chi0v, chi1v, chi2v, chi3v;
-    v4df_t           chi4v;
+    double* restrict av[5] __attribute__((aligned(64)));
 
-    v4df_t           a00v, a01v, a02v, a03v;
-    v4df_t           a04v;
+    double* restrict y0;
 
-    v4df_t           a10v, a11v, a12v, a13v;
-    v4df_t           a14v;
-
-    v4df_t           y0v, y1v;
-
-    double           chi0, chi1, chi2, chi3;
-    double           chi4;
+    v4df_t           chiv[5], a_vec[20], yv[4];
+    
+    double           chi[5];
 
     // If either dimension is zero, or if alpha is zero, return early.
     if ( bli_zero_dim2( m, b_n ) || bli_deq0( *alpha ) ) return;
@@ -354,16 +352,15 @@ void bli_daxpyf_zen_int_5
     // operation as a loop over axpyv.
     if ( b_n != fuse_fac )
     {
-        if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
-
-        axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
+       	if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+      	axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
 
         for ( i = 0; i < b_n; ++i )
         {
-            const double* restrict ap1   = a + (0  )*inca + (i  )*lda;
-            const double* restrict chi1 = x + (i  )*incx;
-                  double* restrict y1   = y + (0  )*incy;
-                  double           alpha_chi1;
+            double* a1   = a + (0  )*inca + (i  )*lda;
+            double* chi1 = x + (i  )*incx;
+            double* y1   = y + (0  )*incy;
+            double  alpha_chi1;
 
             bli_dcopycjs( conjx, *chi1, alpha_chi1 );
             bli_dscals( *alpha, alpha_chi1 );
@@ -373,7 +370,7 @@ void bli_daxpyf_zen_int_5
               conja,
               m,
               &alpha_chi1,
-              ap1, inca,
+              a1, inca,
               y1, incy,
               cntx
             );
@@ -383,172 +380,296 @@ void bli_daxpyf_zen_int_5
     }
 
     // At this point, we know that b_n is exactly equal to the fusing factor.
+    // av points to the 5 columns under consideration
+    av[0]   = a + 0*lda;
+    av[1]   = a + 1*lda;
+    av[2]   = a + 2*lda;
+    av[3]   = a + 3*lda;
+    av[4]   = a + 4*lda;
+    y0   = y;
 
-    const double* restrict ap0   = a + 0*lda;
-    const double* restrict ap1   = a + 1*lda;
-    const double* restrict ap2   = a + 2*lda;
-    const double* restrict ap3   = a + 3*lda;
-    const double* restrict ap4   = a + 4*lda;
-          double* restrict yp   = y;
-
-    chi0 = *( x + 0*incx );
-    chi1 = *( x + 1*incx );
-    chi2 = *( x + 2*incx );
-    chi3 = *( x + 3*incx );
-    chi4 = *( x + 4*incx );
+    chi[0] = *( x + 0*incx );
+    chi[1] = *( x + 1*incx );
+    chi[2] = *( x + 2*incx );
+    chi[3] = *( x + 3*incx );
+    chi[4] = *( x + 4*incx );
 
 
     // Scale each chi scalar by alpha.
-    bli_dscals( *alpha, chi0 );
-    bli_dscals( *alpha, chi1 );
-    bli_dscals( *alpha, chi2 );
-    bli_dscals( *alpha, chi3 );
-    bli_dscals( *alpha, chi4 );
+    bli_dscals( *alpha, chi[0] );
+    bli_dscals( *alpha, chi[1] );
+    bli_dscals( *alpha, chi[2] );
+    bli_dscals( *alpha, chi[3] );
+    bli_dscals( *alpha, chi[4] );
 
     // Broadcast the (alpha*chi?) scalars to all elements of vector registers.
-    chi0v.v = _mm256_broadcast_sd( &chi0 );
-    chi1v.v = _mm256_broadcast_sd( &chi1 );
-    chi2v.v = _mm256_broadcast_sd( &chi2 );
-    chi3v.v = _mm256_broadcast_sd( &chi3 );
-    chi4v.v = _mm256_broadcast_sd( &chi4 );
+    chiv[0].v = _mm256_broadcast_sd( &chi[0] );
+    chiv[1].v = _mm256_broadcast_sd( &chi[1] );
+    chiv[2].v = _mm256_broadcast_sd( &chi[2] );
+    chiv[3].v = _mm256_broadcast_sd( &chi[3] );
+    chiv[4].v = _mm256_broadcast_sd( &chi[4] );
 
     // If there are vectorized iterations, perform them with vector
     // instructions.
     if ( inca == 1 && incy == 1 )
     {
-        for ( i = 0; (i + 7) < m; i += 8 )
+        // 16 elements of the result are computed per iteration
+        for ( i = 0; (i + 15) < m; i += 16 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
+            yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            yv[2].v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+            yv[3].v = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
+            a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+            a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+            a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+            a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+            a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
+            a_vec[5].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+            a_vec[6].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+            a_vec[7].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+            a_vec[8].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+            a_vec[9].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-            a12v.v = _mm256_loadu_pd( ap2 + 1*n_elem_per_reg );
+            a_vec[10].v = _mm256_loadu_pd( av[0] + 2*n_elem_per_reg );
+            a_vec[11].v = _mm256_loadu_pd( av[1] + 2*n_elem_per_reg );
+            a_vec[12].v = _mm256_loadu_pd( av[2] + 2*n_elem_per_reg );
+            a_vec[13].v = _mm256_loadu_pd( av[3] + 2*n_elem_per_reg );
+            a_vec[14].v = _mm256_loadu_pd( av[4] + 2*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-            a13v.v = _mm256_loadu_pd( ap3 + 1*n_elem_per_reg );
-
-            a04v.v = _mm256_loadu_pd( ap4 + 0*n_elem_per_reg );
-            a14v.v = _mm256_loadu_pd( ap4 + 1*n_elem_per_reg );
+            a_vec[15].v = _mm256_loadu_pd( av[0] + 3*n_elem_per_reg );
+            a_vec[16].v = _mm256_loadu_pd( av[1] + 3*n_elem_per_reg );
+            a_vec[17].v = _mm256_loadu_pd( av[2] + 3*n_elem_per_reg );
+            a_vec[18].v = _mm256_loadu_pd( av[3] + 3*n_elem_per_reg );
+            a_vec[19].v = _mm256_loadu_pd( av[4] + 3*n_elem_per_reg );
 
             // perform : y += alpha * x;
-            y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
-            y1v.v = _mm256_fmadd_pd( a10v.v, chi0v.v, y1v.v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
 
-            y0v.v = _mm256_fmadd_pd( a01v.v, chi1v.v, y0v.v );
-            y1v.v = _mm256_fmadd_pd( a11v.v, chi1v.v, y1v.v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[5].v, chiv[0].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[6].v, chiv[1].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[7].v, chiv[2].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[3].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[4].v, yv[1].v );
 
-            y0v.v = _mm256_fmadd_pd( a02v.v, chi2v.v, y0v.v );
-            y1v.v = _mm256_fmadd_pd( a12v.v, chi2v.v, y1v.v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[10].v, chiv[0].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[11].v, chiv[1].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[12].v, chiv[2].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[13].v, chiv[3].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[14].v, chiv[4].v, yv[2].v );
 
-            y0v.v = _mm256_fmadd_pd( a03v.v, chi3v.v, y0v.v );
-            y1v.v = _mm256_fmadd_pd( a13v.v, chi3v.v, y1v.v );
-
-            y0v.v = _mm256_fmadd_pd( a04v.v, chi4v.v, y0v.v );
-            y1v.v = _mm256_fmadd_pd( a14v.v, chi4v.v, y1v.v );
-
+            yv[3].v = _mm256_fmadd_pd( a_vec[15].v, chiv[0].v, yv[3].v );
+            yv[3].v = _mm256_fmadd_pd( a_vec[16].v, chiv[1].v, yv[3].v );
+            yv[3].v = _mm256_fmadd_pd( a_vec[17].v, chiv[2].v, yv[3].v );
+            yv[3].v = _mm256_fmadd_pd( a_vec[18].v, chiv[3].v, yv[3].v );
+            yv[3].v = _mm256_fmadd_pd( a_vec[19].v, chiv[4].v, yv[3].v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+            _mm256_storeu_pd( (y0 + 2*n_elem_per_reg), yv[2].v );
+            _mm256_storeu_pd( (y0 + 3*n_elem_per_reg), yv[3].v );
 
-            yp += n_iter_unroll * n_elem_per_reg;
-            ap0 += n_iter_unroll * n_elem_per_reg;
-            ap1 += n_iter_unroll * n_elem_per_reg;
-            ap2 += n_iter_unroll * n_elem_per_reg;
-            ap3 += n_iter_unroll * n_elem_per_reg;
-            ap4 += n_iter_unroll * n_elem_per_reg;
+            y0 += n_elem_per_reg * 4;
+            av[0] += n_elem_per_reg * 4;
+            av[1] += n_elem_per_reg * 4;
+            av[2] += n_elem_per_reg * 4;
+            av[3] += n_elem_per_reg * 4;
+            av[4] += n_elem_per_reg * 4;
         }
 
+        // 12 elements of the result are computed per iteration
+        for ( ; (i + 11) < m; i += 12 )
+        {
+            // Load the input values.
+            yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            yv[2].v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+
+            a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+            a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+            a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+            a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+            a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+
+            a_vec[5].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+            a_vec[6].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+            a_vec[7].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+            a_vec[8].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+            a_vec[9].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
+
+            a_vec[10].v = _mm256_loadu_pd( av[0] + 2*n_elem_per_reg );
+            a_vec[11].v = _mm256_loadu_pd( av[1] + 2*n_elem_per_reg );
+            a_vec[12].v = _mm256_loadu_pd( av[2] + 2*n_elem_per_reg );
+            a_vec[13].v = _mm256_loadu_pd( av[3] + 2*n_elem_per_reg );
+            a_vec[14].v = _mm256_loadu_pd( av[4] + 2*n_elem_per_reg );
+
+            // perform : y += alpha * x;
+            yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+
+            yv[1].v = _mm256_fmadd_pd( a_vec[5].v, chiv[0].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[6].v, chiv[1].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[7].v, chiv[2].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[3].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[4].v, yv[1].v );
+
+            yv[2].v = _mm256_fmadd_pd( a_vec[10].v, chiv[0].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[11].v, chiv[1].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[12].v, chiv[2].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[13].v, chiv[3].v, yv[2].v );
+            yv[2].v = _mm256_fmadd_pd( a_vec[14].v, chiv[4].v, yv[2].v );
+
+            // Store the output.
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+            _mm256_storeu_pd( (y0 + 2*n_elem_per_reg), yv[2].v );
+
+            y0 += n_elem_per_reg * 3;
+            av[0] += n_elem_per_reg * 3;
+            av[1] += n_elem_per_reg * 3;
+            av[2] += n_elem_per_reg * 3;
+            av[3] += n_elem_per_reg * 3;
+            av[4] += n_elem_per_reg * 3;
+        }
+
+        // 8 elements of the result are computed per iteration
+        for (; (i + 7) < m; i += 8 )
+        {
+            // Load the input values.
+            yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+
+            a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+            a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+            a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+            a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+            a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+
+            a_vec[5].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+            a_vec[6].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+            a_vec[7].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+            a_vec[8].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+            a_vec[9].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
+
+            // perform : y += alpha * x;
+            yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+
+            yv[1].v = _mm256_fmadd_pd( a_vec[5].v, chiv[0].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[6].v, chiv[1].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[7].v, chiv[2].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[3].v, yv[1].v );
+            yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[4].v, yv[1].v );
+
+            // Store the output.
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+            _mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+
+            y0 += n_elem_per_reg * 2;
+            av[0] += n_elem_per_reg * 2;
+            av[1] += n_elem_per_reg * 2;
+            av[2] += n_elem_per_reg * 2;
+            av[3] += n_elem_per_reg * 2;
+            av[4] += n_elem_per_reg * 2;
+        }
+
+        // 4 elements of the result are computed per iteration
         for( ; (i + 3) < m; i += 4 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
+            yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-            a04v.v = _mm256_loadu_pd( ap4 + 0*n_elem_per_reg );
-
+            a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+            a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+            a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+            a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+            a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
 
             // perform : y += alpha * x;
-            y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
-            y0v.v = _mm256_fmadd_pd( a01v.v, chi1v.v, y0v.v );
-            y0v.v = _mm256_fmadd_pd( a02v.v, chi2v.v, y0v.v );
-            y0v.v = _mm256_fmadd_pd( a03v.v, chi3v.v, y0v.v );
-            y0v.v = _mm256_fmadd_pd( a04v.v, chi4v.v, y0v.v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+            yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
 
             // Store the output.
-            _mm256_storeu_pd( (yp + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
 
-            yp += n_elem_per_reg;
-            ap0 += n_elem_per_reg;
-            ap1 += n_elem_per_reg;
-            ap2 += n_elem_per_reg;
-            ap3 += n_elem_per_reg;
-            ap4 += n_elem_per_reg;
+            y0 += n_elem_per_reg;
+            av[0] += n_elem_per_reg;
+            av[1] += n_elem_per_reg;
+            av[2] += n_elem_per_reg;
+            av[3] += n_elem_per_reg;
+            av[4] += n_elem_per_reg;
         }
 
         // If there are leftover iterations, perform them with scalar code.
         for ( ; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
-            const double a2c = *ap2;
-            const double a3c = *ap3;
-            const double a4c = *ap4;
+            const double a0c = *av[0];
+            const double a1c = *av[1];
+            const double a2c = *av[2];
+            const double a3c = *av[3];
+            const double a4c = *av[4];
 
-            y0c += chi0 * a0c;
-            y0c += chi1 * a1c;
-            y0c += chi2 * a2c;
-            y0c += chi3 * a3c;
-            y0c += chi4 * a4c;
+            y0c += chi[0] * a0c;
+            y0c += chi[1] * a1c;
+            y0c += chi[2] * a2c;
+            y0c += chi[3] * a3c;
+            y0c += chi[4] * a4c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += 1;
-            ap1 += 1;
-            ap2 += 1;
-            ap3 += 1;
-            ap4 += 1;
-            yp += 1;
+            av[0] += 1;
+            av[1] += 1;
+            av[2] += 1;
+            av[3] += 1;
+            av[4] += 1;
+            y0 += 1;
         }
     }
     else
     {
         for ( i = 0; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
-            const double a2c = *ap2;
-            const double a3c = *ap3;
-            const double a4c = *ap4;
+            const double a0c = *av[0];
+            const double a1c = *av[1];
+            const double a2c = *av[2];
+            const double a3c = *av[3];
+            const double a4c = *av[4];
 
-            y0c += chi0 * a0c;
-            y0c += chi1 * a1c;
-            y0c += chi2 * a2c;
-            y0c += chi3 * a3c;
-            y0c += chi4 * a4c;
+            y0c += chi[0] * a0c;
+            y0c += chi[1] * a1c;
+            y0c += chi[2] * a2c;
+            y0c += chi[3] * a3c;
+            y0c += chi[4] * a4c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += inca;
-            ap1 += inca;
-            ap2 += inca;
-            ap3 += inca;
-            ap4 += inca;
-            yp += incy;
+            av[0] += inca;
+            av[1] += inca;
+            av[2] += inca;
+            av[3] += inca;
+            av[4] += inca;
+            y0 += incy;
         }
 
     }
@@ -563,23 +684,27 @@ void bli_daxpyf_zen_int_16x2
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const double* restrict alpha = alpha0;
-	const double* restrict a     = a0;
-	const double* restrict x     = x0;
-	      double* restrict y     = y0;
+    double *alpha = (double *)alpha0;
+    double *a = (double *)a00;
+    double *x = (double *)x00;
+    double *y = (double *)y00;
 
     const dim_t      fuse_fac       = 2;
-
     const dim_t      n_elem_per_reg = 4;
     const dim_t      n_iter_unroll  = 4;
 
     dim_t            i;
+
+    double* restrict a0;
+    double* restrict a1;
+
+    double* restrict y0;
 
     v4df_t           chi0v, chi1v;
 
@@ -598,7 +723,6 @@ void bli_daxpyf_zen_int_16x2
     v2df_t           a40v, a41v;
 
     v2df_t           y4v; 
-
     // If either dimension is zero, or if alpha is zero, return early.
     if ( bli_zero_dim2( m, b_n ) || bli_deq0( *alpha ) ) return;
 
@@ -607,15 +731,14 @@ void bli_daxpyf_zen_int_16x2
     if ( b_n != fuse_fac )
     {
         if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
-
         axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
 
         for ( i = 0; i < b_n; ++i )
         {
-            const double* restrict ap1   = a + (0  )*inca + (i  )*lda;
-            const double* restrict chi1 = x + (i  )*incx;
-                  double* restrict y1   = y + (0  )*incy;
-                  double           alpha_chi1;
+            double* a1   = a + (0  )*inca + (i  )*lda;
+            double* chi1 = x + (i  )*incx;
+            double* y1   = y + (0  )*incy;
+            double  alpha_chi1;
 
             bli_dcopycjs( conjx, *chi1, alpha_chi1 );
             bli_dscals( *alpha, alpha_chi1 );
@@ -625,7 +748,7 @@ void bli_daxpyf_zen_int_16x2
               conja,
               m,
               &alpha_chi1,
-              ap1, inca,
+              a1, inca,
               y1, incy,
               cntx
             );
@@ -636,13 +759,13 @@ void bli_daxpyf_zen_int_16x2
 
     // At this point, we know that b_n is exactly equal to the fusing factor.
 
-    const double* restrict ap0   = a + 0*lda;
-    const double* restrict ap1   = a + 1*lda;
+    a0   = a + 0*lda;
+    a1   = a + 1*lda;
 
-          double* restrict yp   = y;
+    y0   = y;
 
-    chi0 = *( x + 0*incx );
-    chi1 = *( x + 1*incx );
+    chi0 = *( (double *)x + 0*incx );
+    chi1 = *( (double *)x + 1*incx );
 
 
     // Scale each chi scalar by alpha.
@@ -660,20 +783,20 @@ void bli_daxpyf_zen_int_16x2
         for ( i = 0; (i + 15) < m; i += 16 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-            y2v.v = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
-            y3v.v = _mm256_loadu_pd( yp + 3*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            y2v.v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+            y3v.v = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
-            a20v.v = _mm256_loadu_pd( ap0 + 2*n_elem_per_reg );
-            a30v.v = _mm256_loadu_pd( ap0 + 3*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
+            a20v.v = _mm256_loadu_pd( a0 + 2*n_elem_per_reg );
+            a30v.v = _mm256_loadu_pd( a0 + 3*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
-            a21v.v = _mm256_loadu_pd( ap1 + 2*n_elem_per_reg );
-            a31v.v = _mm256_loadu_pd( ap1 + 3*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
+            a21v.v = _mm256_loadu_pd( a1 + 2*n_elem_per_reg );
+            a31v.v = _mm256_loadu_pd( a1 + 3*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -687,30 +810,30 @@ void bli_daxpyf_zen_int_16x2
             y3v.v = _mm256_fmadd_pd( a31v.v, chi1v.v, y3v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
-            _mm256_storeu_pd( (double *)(yp + 2*n_elem_per_reg), y2v.v );
-            _mm256_storeu_pd( (double *)(yp + 3*n_elem_per_reg), y3v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 2*n_elem_per_reg), y2v.v );
+            _mm256_storeu_pd( (double *)(y0 + 3*n_elem_per_reg), y3v.v );
 
-            yp += n_iter_unroll * n_elem_per_reg;
-            ap0 += n_iter_unroll * n_elem_per_reg;
-            ap1 += n_iter_unroll * n_elem_per_reg;
+            y0 += n_iter_unroll * n_elem_per_reg;
+            a0 += n_iter_unroll * n_elem_per_reg;
+            a1 += n_iter_unroll * n_elem_per_reg;
         }
 
         for ( ; (i + 11) < m; i += 12 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-            y2v.v = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            y2v.v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
-            a20v.v = _mm256_loadu_pd( ap0 + 2*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
+            a20v.v = _mm256_loadu_pd( a0 + 2*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
-            a21v.v = _mm256_loadu_pd( ap1 + 2*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
+            a21v.v = _mm256_loadu_pd( a1 + 2*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -722,25 +845,25 @@ void bli_daxpyf_zen_int_16x2
             y2v.v = _mm256_fmadd_pd( a21v.v, chi1v.v, y2v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
-            _mm256_storeu_pd( (double *)(yp + 2*n_elem_per_reg), y2v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 2*n_elem_per_reg), y2v.v );
 
-            yp += 3 * n_elem_per_reg;
-            ap0 += 3 * n_elem_per_reg;
-            ap1 += 3 * n_elem_per_reg;
+            y0 += 3 * n_elem_per_reg;
+            a0 += 3 * n_elem_per_reg;
+            a1 += 3 * n_elem_per_reg;
         }
         for ( ; (i + 7) < m; i += 8 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -750,22 +873,22 @@ void bli_daxpyf_zen_int_16x2
             y1v.v = _mm256_fmadd_pd( a11v.v, chi1v.v, y1v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
 
-            yp += 2 * n_elem_per_reg;
-            ap0 += 2 * n_elem_per_reg;
-            ap1 += 2 * n_elem_per_reg;
+            y0 += 2 * n_elem_per_reg;
+            a0 += 2 * n_elem_per_reg;
+            a1 += 2 * n_elem_per_reg;
         }
 
         for ( ; (i + 3) < m; i += 4 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -773,21 +896,21 @@ void bli_daxpyf_zen_int_16x2
             y0v.v = _mm256_fmadd_pd( a01v.v, chi1v.v, y0v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
 
-            yp += n_elem_per_reg;
-            ap0 += n_elem_per_reg;
-            ap1 += n_elem_per_reg;
+            y0 += n_elem_per_reg;
+            a0 += n_elem_per_reg;
+            a1 += n_elem_per_reg;
         }
 
         for ( ; (i + 1) < m; i += 2 )
         {
             // Load the input values.
-            y4v.v = _mm_loadu_pd( yp + 0*n_elem_per_reg );
+            y4v.v = _mm_loadu_pd( y0 + 0*n_elem_per_reg );
 
-            a40v.v = _mm_loadu_pd( ap0 + 0*n_elem_per_reg );
+            a40v.v = _mm_loadu_pd( a0 + 0*n_elem_per_reg );
 
-            a41v.v = _mm_loadu_pd( ap1 + 0*n_elem_per_reg );
+            a41v.v = _mm_loadu_pd( a1 + 0*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y4v.v = _mm_fmadd_pd( a40v.v, chi0v.xmm[0], y4v.v );
@@ -795,55 +918,54 @@ void bli_daxpyf_zen_int_16x2
             y4v.v = _mm_fmadd_pd( a41v.v, chi1v.xmm[0], y4v.v );
 
             // Store the output.
-            _mm_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y4v.v );
+            _mm_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y4v.v );
 
-            yp += 2;
-            ap0 += 2;
-            ap1 += 2;
+            y0 += 2;
+            a0 += 2;
+            a1 += 2;
         }
 
         // If there are leftover iterations, perform them with scalar code.
         for ( ; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
+            const double a0c = *a0;
+            const double a1c = *a1;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += 1;
-            ap1 += 1;
-            yp += 1;
+            a0 += 1;
+            a1 += 1;
+            y0 += 1;
         }
     }
     else
     {
         for ( i = 0; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
+            const double a0c = *a0;
+            const double a1c = *a1;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += inca;
-            ap1 += inca;
-            yp += incy;
+            a0 += inca;
+            a1 += inca;
+            y0 += incy;
         }
 
     }
 }
 
 // -----------------------------------------------------------------------------
-
 void bli_daxpyf_zen_int_16x4
      (
              conj_t  conja,
@@ -851,23 +973,29 @@ void bli_daxpyf_zen_int_16x4
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const double* restrict alpha = alpha0;
-	const double* restrict a     = a0;
-	const double* restrict x     = x0;
-	      double* restrict y     = y0;
+    double *alpha = (double *)alpha0;
+    double *a = (double *)a00;
+    double *x = (double *)x00;
+    double *y = (double *)y00;
 
     const dim_t      fuse_fac       = 4;
-
     const dim_t      n_elem_per_reg = 4;
     const dim_t      n_iter_unroll  = 4;
 
     dim_t            i;
+
+    double* restrict a0;
+    double* restrict a1;
+    double* restrict a2;
+    double* restrict a3;
+
+    double* restrict y0;
 
     v4df_t           chi0v, chi1v, chi2v, chi3v;
 
@@ -895,15 +1023,14 @@ void bli_daxpyf_zen_int_16x4
     if ( b_n != fuse_fac )
     {
         if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
-
         axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
 
         for ( i = 0; i < b_n; ++i )
         {
-            const double* restrict ap1   = a + (0  )*inca + (i  )*lda;
-            const double* restrict chi1 = x + (i  )*incx;
-                  double* restrict y1   = y + (0  )*incy;
-                  double           alpha_chi1;
+            double* a1   = a + (0  )*inca + (i  )*lda;
+            double* chi1 = x + (i  )*incx;
+            double* y1   = y + (0  )*incy;
+            double  alpha_chi1;
 
             bli_dcopycjs( conjx, *chi1, alpha_chi1 );
             bli_dscals( *alpha, alpha_chi1 );
@@ -913,7 +1040,7 @@ void bli_daxpyf_zen_int_16x4
               conja,
               m,
               &alpha_chi1,
-              ap1, inca,
+              a1, inca,
               y1, incy,
               cntx
             );
@@ -924,12 +1051,12 @@ void bli_daxpyf_zen_int_16x4
 
     // At this point, we know that b_n is exactly equal to the fusing factor.
 
-    const double* restrict ap0   = a + 0*lda;
-    const double* restrict ap1   = a + 1*lda;
-    const double* restrict ap2   = a + 2*lda;
-    const double* restrict ap3   = a + 3*lda;
+    a0   = a + 0*lda;
+    a1   = a + 1*lda;
+    a2   = a + 2*lda;
+    a3   = a + 3*lda;
 
-          double* restrict yp   = y;
+    y0   = y;
 
     chi0 = *( x + 0*incx );
     chi1 = *( x + 1*incx );
@@ -955,32 +1082,32 @@ void bli_daxpyf_zen_int_16x4
         for ( i = 0; (i + 15) < m; i += 16 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-            y2v.v = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
-            y3v.v = _mm256_loadu_pd( yp + 3*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            y2v.v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+            y3v.v = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
-            a20v.v = _mm256_loadu_pd( ap0 + 2*n_elem_per_reg );
-            a30v.v = _mm256_loadu_pd( ap0 + 3*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
+            a20v.v = _mm256_loadu_pd( a0 + 2*n_elem_per_reg );
+            a30v.v = _mm256_loadu_pd( a0 + 3*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
-            a21v.v = _mm256_loadu_pd( ap1 + 2*n_elem_per_reg );
-            a31v.v = _mm256_loadu_pd( ap1 + 3*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
+            a21v.v = _mm256_loadu_pd( a1 + 2*n_elem_per_reg );
+            a31v.v = _mm256_loadu_pd( a1 + 3*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-            a12v.v = _mm256_loadu_pd( ap2 + 1*n_elem_per_reg );
-            a22v.v = _mm256_loadu_pd( ap2 + 2*n_elem_per_reg );
-            a32v.v = _mm256_loadu_pd( ap2 + 3*n_elem_per_reg );
+            a02v.v = _mm256_loadu_pd( a2 + 0*n_elem_per_reg );
+            a12v.v = _mm256_loadu_pd( a2 + 1*n_elem_per_reg );
+            a22v.v = _mm256_loadu_pd( a2 + 2*n_elem_per_reg );
+            a32v.v = _mm256_loadu_pd( a2 + 3*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-            a13v.v = _mm256_loadu_pd( ap3 + 1*n_elem_per_reg );
-            a23v.v = _mm256_loadu_pd( ap3 + 2*n_elem_per_reg );
-            a33v.v = _mm256_loadu_pd( ap3 + 3*n_elem_per_reg );
+            a03v.v = _mm256_loadu_pd( a3 + 0*n_elem_per_reg );
+            a13v.v = _mm256_loadu_pd( a3 + 1*n_elem_per_reg );
+            a23v.v = _mm256_loadu_pd( a3 + 2*n_elem_per_reg );
+            a33v.v = _mm256_loadu_pd( a3 + 3*n_elem_per_reg );
 
-            // perform : y += alpha * x;
+        // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
             y1v.v = _mm256_fmadd_pd( a10v.v, chi0v.v, y1v.v );
             y2v.v = _mm256_fmadd_pd( a20v.v, chi0v.v, y2v.v );
@@ -1002,40 +1129,40 @@ void bli_daxpyf_zen_int_16x4
             y3v.v = _mm256_fmadd_pd( a33v.v, chi3v.v, y3v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
-            _mm256_storeu_pd( (double *)(yp + 2*n_elem_per_reg), y2v.v );
-            _mm256_storeu_pd( (double *)(yp + 3*n_elem_per_reg), y3v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 2*n_elem_per_reg), y2v.v );
+            _mm256_storeu_pd( (double *)(y0 + 3*n_elem_per_reg), y3v.v );
 
-            yp += n_iter_unroll * n_elem_per_reg;
-            ap0 += n_iter_unroll * n_elem_per_reg;
-            ap1 += n_iter_unroll * n_elem_per_reg;
-            ap2 += n_iter_unroll * n_elem_per_reg;
-            ap3 += n_iter_unroll * n_elem_per_reg;
+            y0 += n_iter_unroll * n_elem_per_reg;
+            a0 += n_iter_unroll * n_elem_per_reg;
+            a1 += n_iter_unroll * n_elem_per_reg;
+            a2 += n_iter_unroll * n_elem_per_reg;
+            a3 += n_iter_unroll * n_elem_per_reg;
         }
 
         for ( ; (i + 11) < m; i += 12 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
-            y2v.v = _mm256_loadu_pd( yp + 2*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+            y2v.v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
-            a20v.v = _mm256_loadu_pd( ap0 + 2*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
+            a20v.v = _mm256_loadu_pd( a0 + 2*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
-            a21v.v = _mm256_loadu_pd( ap1 + 2*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
+            a21v.v = _mm256_loadu_pd( a1 + 2*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-            a12v.v = _mm256_loadu_pd( ap2 + 1*n_elem_per_reg );
-            a22v.v = _mm256_loadu_pd( ap2 + 2*n_elem_per_reg );
+            a02v.v = _mm256_loadu_pd( a2 + 0*n_elem_per_reg );
+            a12v.v = _mm256_loadu_pd( a2 + 1*n_elem_per_reg );
+            a22v.v = _mm256_loadu_pd( a2 + 2*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-            a13v.v = _mm256_loadu_pd( ap3 + 1*n_elem_per_reg );
-            a23v.v = _mm256_loadu_pd( ap3 + 2*n_elem_per_reg );
+            a03v.v = _mm256_loadu_pd( a3 + 0*n_elem_per_reg );
+            a13v.v = _mm256_loadu_pd( a3 + 1*n_elem_per_reg );
+            a23v.v = _mm256_loadu_pd( a3 + 2*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -1055,34 +1182,34 @@ void bli_daxpyf_zen_int_16x4
             y2v.v = _mm256_fmadd_pd( a23v.v, chi3v.v, y2v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
-            _mm256_storeu_pd( (double *)(yp + 2*n_elem_per_reg), y2v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 2*n_elem_per_reg), y2v.v );
 
-            yp += 3 * n_elem_per_reg;
-            ap0 += 3 * n_elem_per_reg;
-            ap1 += 3 * n_elem_per_reg;
-            ap2 += 3 * n_elem_per_reg;
-            ap3 += 3 * n_elem_per_reg;
+            y0 += 3 * n_elem_per_reg;
+            a0 += 3 * n_elem_per_reg;
+            a1 += 3 * n_elem_per_reg;
+            a2 += 3 * n_elem_per_reg;
+            a3 += 3 * n_elem_per_reg;
         }
 
         for ( ; (i + 7) < m; i += 8 )
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
-            y1v.v = _mm256_loadu_pd( yp + 1*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+            y1v.v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-            a10v.v = _mm256_loadu_pd( ap0 + 1*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
+            a10v.v = _mm256_loadu_pd( a0 + 1*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-            a11v.v = _mm256_loadu_pd( ap1 + 1*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
+            a11v.v = _mm256_loadu_pd( a1 + 1*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-            a12v.v = _mm256_loadu_pd( ap2 + 1*n_elem_per_reg );
+            a02v.v = _mm256_loadu_pd( a2 + 0*n_elem_per_reg );
+            a12v.v = _mm256_loadu_pd( a2 + 1*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-            a13v.v = _mm256_loadu_pd( ap3 + 1*n_elem_per_reg );
+            a03v.v = _mm256_loadu_pd( a3 + 0*n_elem_per_reg );
+            a13v.v = _mm256_loadu_pd( a3 + 1*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -1098,29 +1225,29 @@ void bli_daxpyf_zen_int_16x4
             y1v.v = _mm256_fmadd_pd( a13v.v, chi3v.v, y1v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
-            _mm256_storeu_pd( (double *)(yp + 1*n_elem_per_reg), y1v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 1*n_elem_per_reg), y1v.v );
 
-            yp += 2 * n_elem_per_reg;
-            ap0 += 2 * n_elem_per_reg;
-            ap1 += 2 * n_elem_per_reg;
-            ap2 += 2 * n_elem_per_reg;
-            ap3 += 2 * n_elem_per_reg;
+            y0 += 2 * n_elem_per_reg;
+            a0 += 2 * n_elem_per_reg;
+            a1 += 2 * n_elem_per_reg;
+            a2 += 2 * n_elem_per_reg;
+            a3 += 2 * n_elem_per_reg;
         }
 
 
         for ( ; (i + 3) < m; i += 4)
         {
             // Load the input values.
-            y0v.v = _mm256_loadu_pd( yp + 0*n_elem_per_reg );
+            y0v.v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
 
-            a00v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
+            a00v.v = _mm256_loadu_pd( a0 + 0*n_elem_per_reg );
 
-            a01v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
+            a01v.v = _mm256_loadu_pd( a1 + 0*n_elem_per_reg );
 
-            a02v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
+            a02v.v = _mm256_loadu_pd( a2 + 0*n_elem_per_reg );
 
-            a03v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
+            a03v.v = _mm256_loadu_pd( a3 + 0*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y0v.v = _mm256_fmadd_pd( a00v.v, chi0v.v, y0v.v );
@@ -1132,28 +1259,28 @@ void bli_daxpyf_zen_int_16x4
             y0v.v = _mm256_fmadd_pd( a03v.v, chi3v.v, y0v.v );
 
             // Store the output.
-            _mm256_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y0v.v );
 
-            yp += n_elem_per_reg;
-            ap0 += n_elem_per_reg;
-            ap1 += n_elem_per_reg;
-            ap2 += n_elem_per_reg;
-            ap3 += n_elem_per_reg;
+            y0 += n_elem_per_reg;
+            a0 += n_elem_per_reg;
+            a1 += n_elem_per_reg;
+            a2 += n_elem_per_reg;
+            a3 += n_elem_per_reg;
         }
-#if 1
+
         for ( ; (i + 1) < m; i += 2)
         {
 
-            // Load the input values.
-            y4v.v  = _mm_loadu_pd( yp + 0*n_elem_per_reg );
+	    // Load the input values.
+            y4v.v  = _mm_loadu_pd( y0 + 0*n_elem_per_reg );
 
-            a40v.v = _mm_loadu_pd( ap0 + 0*n_elem_per_reg );
+            a40v.v = _mm_loadu_pd( a0 + 0*n_elem_per_reg );
 
-            a41v.v = _mm_loadu_pd( ap1 + 0*n_elem_per_reg );
+            a41v.v = _mm_loadu_pd( a1 + 0*n_elem_per_reg );
 
-            a42v.v = _mm_loadu_pd( ap2 + 0*n_elem_per_reg );
+            a42v.v = _mm_loadu_pd( a2 + 0*n_elem_per_reg );
 
-            a43v.v = _mm_loadu_pd( ap3 + 0*n_elem_per_reg );
+            a43v.v = _mm_loadu_pd( a3 + 0*n_elem_per_reg );
 
             // perform : y += alpha * x;
             y4v.v = _mm_fmadd_pd( a40v.v, chi0v.xmm[0], y4v.v );
@@ -1165,67 +1292,1007 @@ void bli_daxpyf_zen_int_16x4
             y4v.v = _mm_fmadd_pd( a43v.v, chi3v.xmm[0], y4v.v );
 
             // Store the output.
-            _mm_storeu_pd( (double *)(yp + 0*n_elem_per_reg), y4v.v );
+            _mm_storeu_pd( (double *)(y0 + 0*n_elem_per_reg), y4v.v );
 
-            yp += 2;
-            ap0 += 2;
-            ap1 += 2;
-            ap2 += 2;
-            ap3 += 2;
+            y0 += 2;
+            a0 += 2;
+            a1 += 2;
+            a2 += 2;
+            a3 += 2;
         }
-#endif
+
         // If there are leftover iterations, perform them with scalar code.
         for ( ; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
-            const double a2c = *ap2;
-            const double a3c = *ap3;
+            const double a0c = *a0;
+            const double a1c = *a1;
+            const double a2c = *a2;
+            const double a3c = *a3;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
             y0c += chi2 * a2c;
             y0c += chi3 * a3c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += 1;
-            ap1 += 1;
-            ap2 += 1;
-            ap3 += 1;
+            a0 += 1;
+            a1 += 1;
+            a2 += 1;
+            a3 += 1;
 
-            yp += 1;
+            y0 += 1;
         }
     }
     else
     {
         for ( i = 0; (i + 0) < m ; ++i )
         {
-            double       y0c = *yp;
+            double       y0c = *y0;
 
-            const double a0c = *ap0;
-            const double a1c = *ap1;
-            const double a2c = *ap2;
-            const double a3c = *ap3;
+            const double a0c = *a0;
+            const double a1c = *a1;
+            const double a2c = *a2;
+            const double a3c = *a3;
 
             y0c += chi0 * a0c;
             y0c += chi1 * a1c;
             y0c += chi2 * a2c;
             y0c += chi3 * a3c;
 
-            *yp = y0c;
+            *y0 = y0c;
 
-            ap0 += inca;
-            ap1 += inca;
-            ap2 += inca;
-            ap3 += inca;
+            a0 += inca;
+            a1 += inca;
+            a2 += inca;
+            a3 += inca;
 
-            yp += incy;
+	    y0 += incy;
         }
 
     }
 }
 
+// -----------------------------------------------------------------------------
 
+void bli_caxpyf_zen_int_5
+     (
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b_n,
+       const void*   alpha0,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
+       const cntx_t* cntx
+     )
+{
+    scomplex *alpha = (scomplex *)alpha0;
+    scomplex *a = (scomplex *)a00;
+    scomplex *x = (scomplex *)x00;
+    scomplex *y = (scomplex *)y00;
+
+    const dim_t         fuse_fac       = 5;
+    const dim_t         n_elem_per_reg = 4;
+
+    dim_t               i = 0;
+    dim_t               setPlusOne = 1;
+
+    v8sf_t              chi0v, chi1v, chi2v, chi3v, chi4v;
+    v8sf_t              chi5v, chi6v, chi7v, chi8v, chi9v;
+
+    v8sf_t              a00v, a01v, a02v, a03v, a04v;
+    v8sf_t              a05v, a06v, a07v, a08v, a09v;
+#if 0
+    v8sf_t              a10v, a11v, a12v, a13v, a14v;
+    v8sf_t              a15v, a16v, a17v, a18v, a19v;
+    v8sf_t              y1v;
+#endif
+    v8sf_t              y0v;
+    v8sf_t              setMinus, setPlus;
+
+    scomplex* restrict  a0;
+    scomplex* restrict  a1;
+    scomplex* restrict  a2;
+    scomplex* restrict  a3;
+    scomplex* restrict  a4;
+
+    scomplex* restrict  y0;
+
+    scomplex            chi0;
+    scomplex            chi1;
+    scomplex            chi2;
+    scomplex            chi3;
+    scomplex            chi4;
+
+    if ( bli_is_conj(conja) ){
+        setPlusOne = -1;
+    }
+
+    // If either dimension is zero, or if alpha is zero, return early.
+    if ( bli_zero_dim2( m, b_n ) || bli_ceq0( *alpha ) ) return;
+
+    // If b_n is not equal to the fusing factor, then perform the entire
+    // operation as a loop over axpyv.
+    if ( b_n != fuse_fac )
+    {
+        if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+        axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_SCOMPLEX, BLIS_AXPYV_KER, cntx );
+
+        for ( i = 0; i < b_n; ++i )
+        {
+            scomplex* a1   = a + (0  )*inca + (i  )*lda;
+            scomplex* chi1 = x + (i  )*incx;
+            scomplex* y1   = y + (0  )*incy;
+            scomplex  alpha_chi1;
+
+            bli_ccopycjs( conjx, *chi1, alpha_chi1 );
+            bli_cscals( *alpha, alpha_chi1 );
+
+            f
+            (
+              conja,
+              m,
+              &alpha_chi1,
+              a1, inca,
+              y1, incy,
+              cntx
+            );
+        }
+
+        return;
+    }
+
+
+    // At this point, we know that b_n is exactly equal to the fusing factor.
+
+    a0   = a + 0*lda;
+    a1   = a + 1*lda;
+    a2   = a + 2*lda;
+    a3   = a + 3*lda;
+    a4   = a + 4*lda;
+    y0   = y;
+
+    chi0 = *( x + 0*incx );
+    chi1 = *( x + 1*incx );
+    chi2 = *( x + 2*incx );
+    chi3 = *( x + 3*incx );
+    chi4 = *( x + 4*incx );
+
+    scomplex *pchi0 = x + 0*incx ;
+    scomplex *pchi1 = x + 1*incx ;
+    scomplex *pchi2 = x + 2*incx ;
+    scomplex *pchi3 = x + 3*incx ;
+    scomplex *pchi4 = x + 4*incx ;
+
+    bli_ccopycjs( conjx, *pchi0, chi0 );
+    bli_ccopycjs( conjx, *pchi1, chi1 );
+    bli_ccopycjs( conjx, *pchi2, chi2 );
+    bli_ccopycjs( conjx, *pchi3, chi3 );
+    bli_ccopycjs( conjx, *pchi4, chi4 );
+
+    // Scale each chi scalar by alpha.
+    bli_cscals( *alpha, chi0 );
+    bli_cscals( *alpha, chi1 );
+    bli_cscals( *alpha, chi2 );
+    bli_cscals( *alpha, chi3 );
+    bli_cscals( *alpha, chi4 );
+
+    // Broadcast the (alpha*chi?) scalars to all elements of vector registers.
+    chi0v.v = _mm256_broadcast_ss( &chi0.real );
+    chi1v.v = _mm256_broadcast_ss( &chi1.real );
+    chi2v.v = _mm256_broadcast_ss( &chi2.real );
+    chi3v.v = _mm256_broadcast_ss( &chi3.real );
+    chi4v.v = _mm256_broadcast_ss( &chi4.real );
+
+    chi5v.v = _mm256_broadcast_ss( &chi0.imag );
+    chi6v.v = _mm256_broadcast_ss( &chi1.imag );
+    chi7v.v = _mm256_broadcast_ss( &chi2.imag );
+    chi8v.v = _mm256_broadcast_ss( &chi3.imag );
+    chi9v.v = _mm256_broadcast_ss( &chi4.imag );
+
+    // If there are vectorized iterations, perform them with vector
+    // instructions.
+    if ( inca == 1 && incy == 1 )
+    {
+        setMinus.v = _mm256_set_ps( -1, 1, -1, 1, -1, 1, -1, 1 );
+
+        setPlus.v = _mm256_set1_ps( 1 );
+        if ( bli_is_conj(conja) ){
+            setPlus.v = _mm256_set_ps( -1, 1, -1, 1, -1, 1, -1, 1 );
+        }
+
+        /*
+         y := y + alpha * conja(A) * conjx(x)
+
+          nn
+          (ar + ai) (xr + xi)
+          ar * xr - ai * xi
+          ar * xi + ai * xr
+
+         cc : (ar - ai) (xr - xi)
+          ar * xr - ai * xi
+          -(ar * xi + ai * xr)
+
+          nc : (ar + ai) (xr - xi)
+           ar * xr + ai * xi
+          -(ar * xi - ai * xr)
+
+          cn : (ar - ai) (xr + xi)
+           ar * xr + ai * xi
+          ar * xi - ai * xr
+
+        */
+
+        i = 0;
+#if 0 //Low performance
+        for( i = 0; (i + 7) < m; i += 8 )
+        {
+            // Load the input values.
+            y0v.v = _mm256_loadu_ps( (float*) (y0 + 0*n_elem_per_reg ));
+            y1v.v = _mm256_loadu_ps( (float*) (y0 + 1*n_elem_per_reg ));
+
+            a00v.v = _mm256_loadu_ps( (float*) (a0 + 0*n_elem_per_reg ));
+            a10v.v = _mm256_loadu_ps( (float*) (a0 + 1*n_elem_per_reg ));
+
+            a01v.v = _mm256_loadu_ps( (float*) (a1 + 0*n_elem_per_reg ));
+            a11v.v = _mm256_loadu_ps( (float*) (a1 + 1*n_elem_per_reg ));
+
+            a02v.v = _mm256_loadu_ps( (float*) (a2 + 0*n_elem_per_reg ));
+            a12v.v = _mm256_loadu_ps( (float*) (a2 + 1*n_elem_per_reg ));
+
+            a03v.v = _mm256_loadu_ps( (float*) (a3 + 0*n_elem_per_reg ));
+            a13v.v = _mm256_loadu_ps( (float*) (a3 + 1*n_elem_per_reg ));
+
+            a04v.v = _mm256_loadu_ps( (float*) (a4 + 0*n_elem_per_reg ));
+            a14v.v = _mm256_loadu_ps( (float*) (a4 + 1*n_elem_per_reg ));
+
+            a00v.v = _mm256_mul_ps( a00v.v, setPlus.v );
+            a01v.v = _mm256_mul_ps( a01v.v, setPlus.v );
+            a02v.v = _mm256_mul_ps( a02v.v, setPlus.v );
+            a03v.v = _mm256_mul_ps( a03v.v, setPlus.v );
+            a04v.v = _mm256_mul_ps( a04v.v, setPlus.v );
+
+            a05v.v = _mm256_mul_ps( a00v.v, setMinus.v );
+            a06v.v = _mm256_mul_ps( a01v.v, setMinus.v );
+            a07v.v = _mm256_mul_ps( a02v.v, setMinus.v );
+            a08v.v = _mm256_mul_ps( a03v.v, setMinus.v );
+            a09v.v = _mm256_mul_ps( a04v.v, setMinus.v );
+
+            a05v.v = _mm256_permute_ps( a05v.v, 0xB1 );
+            a06v.v = _mm256_permute_ps( a06v.v, 0xB1 );
+            a07v.v = _mm256_permute_ps( a07v.v, 0xB1 );
+            a08v.v = _mm256_permute_ps( a08v.v, 0xB1 );
+            a09v.v = _mm256_permute_ps( a09v.v, 0xB1 );
+
+            a10v.v = _mm256_mul_ps( a10v.v, setPlus.v );
+            a11v.v = _mm256_mul_ps( a11v.v, setPlus.v );
+            a12v.v = _mm256_mul_ps( a12v.v, setPlus.v );
+            a13v.v = _mm256_mul_ps( a13v.v, setPlus.v );
+            a14v.v = _mm256_mul_ps( a14v.v, setPlus.v );
+
+            a15v.v = _mm256_mul_ps( a10v.v, setMinus.v );
+            a16v.v = _mm256_mul_ps( a11v.v, setMinus.v );
+            a17v.v = _mm256_mul_ps( a12v.v, setMinus.v );
+            a18v.v = _mm256_mul_ps( a13v.v, setMinus.v );
+            a19v.v = _mm256_mul_ps( a14v.v, setMinus.v );
+
+            a15v.v = _mm256_permute_ps( a15v.v, 0xB1 );
+            a16v.v = _mm256_permute_ps( a16v.v, 0xB1 );
+            a17v.v = _mm256_permute_ps( a17v.v, 0xB1 );
+            a18v.v = _mm256_permute_ps( a18v.v, 0xB1 );
+            a19v.v = _mm256_permute_ps( a19v.v, 0xB1 );
+
+            // perform : y += alpha * x;
+            y0v.v = _mm256_fmadd_ps( a00v.v, chi0v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a01v.v, chi1v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a02v.v, chi2v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a03v.v, chi3v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a04v.v, chi4v.v, y0v.v );
+
+            y0v.v = _mm256_fmadd_ps( a05v.v, chi5v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a06v.v, chi6v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a07v.v, chi7v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a08v.v, chi8v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a09v.v, chi9v.v, y0v.v );
+
+            // For next 4 elements perform : y += alpha * x;
+            y1v.v = _mm256_fmadd_ps( a10v.v, chi0v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a11v.v, chi1v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a12v.v, chi2v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a13v.v, chi3v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a14v.v, chi4v.v, y1v.v );
+
+            y1v.v = _mm256_fmadd_ps( a15v.v, chi5v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a16v.v, chi6v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a17v.v, chi7v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a18v.v, chi8v.v, y1v.v );
+            y1v.v = _mm256_fmadd_ps( a19v.v, chi9v.v, y1v.v );
+
+            // Store the output.
+            _mm256_storeu_ps( (float *)(y0 + 0*n_elem_per_reg), y0v.v );
+            _mm256_storeu_ps( (float *)(y0 + 1*n_elem_per_reg), y1v.v );
+
+            y0 += n_elem_per_reg * n_iter_unroll;
+            a0 += n_elem_per_reg * n_iter_unroll;
+            a1 += n_elem_per_reg * n_iter_unroll;
+            a2 += n_elem_per_reg * n_iter_unroll;
+            a3 += n_elem_per_reg * n_iter_unroll;
+            a4 += n_elem_per_reg * n_iter_unroll;
+        }
+#endif
+        for( ; (i + 3) < m; i += 4 )
+        {
+            // Load the input values.
+            y0v.v = _mm256_loadu_ps( (float*) (y0 + 0*n_elem_per_reg ));
+
+            a00v.v = _mm256_loadu_ps( (float*) (a0 + 0*n_elem_per_reg ));
+            a01v.v = _mm256_loadu_ps( (float*) (a1 + 0*n_elem_per_reg ));
+            a02v.v = _mm256_loadu_ps( (float*) (a2 + 0*n_elem_per_reg ));
+            a03v.v = _mm256_loadu_ps( (float*) (a3 + 0*n_elem_per_reg ));
+            a04v.v = _mm256_loadu_ps( (float*) (a4 + 0*n_elem_per_reg ));
+
+            a00v.v = _mm256_mul_ps( a00v.v, setPlus.v );
+            a01v.v = _mm256_mul_ps( a01v.v, setPlus.v );
+            a02v.v = _mm256_mul_ps( a02v.v, setPlus.v );
+            a03v.v = _mm256_mul_ps( a03v.v, setPlus.v );
+            a04v.v = _mm256_mul_ps( a04v.v, setPlus.v );
+
+            a05v.v = _mm256_mul_ps( a00v.v, setMinus.v );
+            a06v.v = _mm256_mul_ps( a01v.v, setMinus.v );
+            a07v.v = _mm256_mul_ps( a02v.v, setMinus.v );
+            a08v.v = _mm256_mul_ps( a03v.v, setMinus.v );
+            a09v.v = _mm256_mul_ps( a04v.v, setMinus.v );
+
+            a05v.v = _mm256_permute_ps( a05v.v, 0xB1 );
+            a06v.v = _mm256_permute_ps( a06v.v, 0xB1 );
+            a07v.v = _mm256_permute_ps( a07v.v, 0xB1 );
+            a08v.v = _mm256_permute_ps( a08v.v, 0xB1 );
+            a09v.v = _mm256_permute_ps( a09v.v, 0xB1 );
+
+            // perform : y += alpha * x;
+            y0v.v = _mm256_fmadd_ps( a00v.v, chi0v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a01v.v, chi1v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a02v.v, chi2v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a03v.v, chi3v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a04v.v, chi4v.v, y0v.v );
+
+            y0v.v = _mm256_fmadd_ps( a05v.v, chi5v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a06v.v, chi6v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a07v.v, chi7v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a08v.v, chi8v.v, y0v.v );
+            y0v.v = _mm256_fmadd_ps( a09v.v, chi9v.v, y0v.v );
+
+            // Store the output.
+            _mm256_storeu_ps( (float *)(y0 + 0*n_elem_per_reg), y0v.v );
+
+            y0 += n_elem_per_reg ;
+            a0 += n_elem_per_reg ;
+            a1 += n_elem_per_reg ;
+            a2 += n_elem_per_reg ;
+            a3 += n_elem_per_reg ;
+            a4 += n_elem_per_reg ;
+        }
+
+        // If there are leftover iterations, perform them with scalar code.
+        for ( ; (i + 0) < m ; ++i )
+        {
+            scomplex       y0c = *y0;
+
+            const scomplex a0c = *a0;
+            const scomplex a1c = *a1;
+            const scomplex a2c = *a2;
+            const scomplex a3c = *a3;
+            const scomplex a4c = *a4;
+
+            y0c.real += chi0.real * a0c.real - chi0.imag * a0c.imag * setPlusOne;
+            y0c.real += chi1.real * a1c.real - chi1.imag * a1c.imag * setPlusOne;
+            y0c.real += chi2.real * a2c.real - chi2.imag * a2c.imag * setPlusOne;
+            y0c.real += chi3.real * a3c.real - chi3.imag * a3c.imag * setPlusOne;
+            y0c.real += chi4.real * a4c.real - chi4.imag * a4c.imag * setPlusOne;
+
+            y0c.imag += chi0.imag * a0c.real + chi0.real * a0c.imag * setPlusOne;
+            y0c.imag += chi1.imag * a1c.real + chi1.real * a1c.imag * setPlusOne;
+            y0c.imag += chi2.imag * a2c.real + chi2.real * a2c.imag * setPlusOne;
+            y0c.imag += chi3.imag * a3c.real + chi3.real * a3c.imag * setPlusOne;
+            y0c.imag += chi4.imag * a4c.real + chi4.real * a4c.imag * setPlusOne;
+
+            *y0 = y0c;
+
+            a0 += 1;
+            a1 += 1;
+            a2 += 1;
+            a3 += 1;
+            a4 += 1;
+            y0 += 1;
+        }
+
+    }
+    else
+    {
+        for ( ; (i + 0) < m ; ++i )
+        {
+            scomplex       y0c = *y0;
+            const scomplex a0c = *a0;
+            const scomplex a1c = *a1;
+            const scomplex a2c = *a2;
+            const scomplex a3c = *a3;
+            const scomplex a4c = *a4;
+
+            y0c.real += chi0.real * a0c.real - chi0.imag * a0c.imag * setPlusOne;
+            y0c.real += chi1.real * a1c.real - chi1.imag * a1c.imag * setPlusOne;
+            y0c.real += chi2.real * a2c.real - chi2.imag * a2c.imag * setPlusOne;
+            y0c.real += chi3.real * a3c.real - chi3.imag * a3c.imag * setPlusOne;
+            y0c.real += chi4.real * a4c.real - chi4.imag * a4c.imag * setPlusOne;
+
+            y0c.imag += chi0.imag * a0c.real + chi0.real * a0c.imag * setPlusOne;
+            y0c.imag += chi1.imag * a1c.real + chi1.real * a1c.imag * setPlusOne;
+            y0c.imag += chi2.imag * a2c.real + chi2.real * a2c.imag * setPlusOne;
+            y0c.imag += chi3.imag * a3c.real + chi3.real * a3c.imag * setPlusOne;
+            y0c.imag += chi4.imag * a4c.real + chi4.real * a4c.imag * setPlusOne;
+
+            *y0 = y0c;
+
+            a0 += inca;
+            a1 += inca;
+            a2 += inca;
+            a3 += inca;
+            a4 += inca;
+            y0 += incy;
+        }
+    }
+}
+
+
+//------------------------------------------------------------------------------
+/**
+ * Following kernel performs axpyf operation on dcomplex data.
+ * Operate over 5 columns of a matrix at a time and march through
+ * rows in steps of 4 or 2.
+ * For optimal performance, it separate outs imaginary and real
+ * components of chis and broadcast them into separate ymm vector
+ * registers.
+ * By doing so it avoids necessity of permute operation to get the
+ * final result of dcomp-lex multiplication.
+ */
+void bli_zaxpyf_zen_int_5
+     (
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b_n,
+       const void*   alpha0,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
+       const cntx_t* cntx
+     )
+{
+
+    dcomplex *alpha = (dcomplex *)alpha0;
+    dcomplex *a = (dcomplex *)a00;
+    dcomplex *x = (dcomplex *)x00;
+    dcomplex *y = (dcomplex *)y00;
+
+	const dim_t              fuse_fac       = 5;
+	const dim_t              n_elem_per_reg = 2;
+	const dim_t              n_iter_unroll  = 2;
+
+	dim_t                    i = 0;
+	dim_t                    setPlusOne = 1;
+
+	v4df_t                   chi0v, chi1v, chi2v, chi3v, chi4v;
+	v4df_t                   chi5v, chi6v, chi7v, chi8v, chi9v;
+
+	v4df_t                   a00v, a01v, a02v, a03v, a04v;
+
+	v4df_t                   a10v, a11v, a12v, a13v, a14v;
+
+	v4df_t                   y0v, y1v, y2v, y3v;
+	v4df_t                   r0v, r1v, conjv;
+
+	dcomplex                 chi0, chi1, chi2, chi3, chi4;
+	dcomplex* restrict       a0;
+	dcomplex* restrict       a1;
+	dcomplex* restrict       a2;
+	dcomplex* restrict       a3;
+	dcomplex* restrict       a4;
+
+	dcomplex*                restrict y0;
+
+
+	if ( bli_is_conj(conja) ){
+		setPlusOne = -1;
+	}
+
+	// If either dimension is zero, or if alpha is zero, return early.
+	if ( bli_zero_dim2( m, b_n ) || bli_zeq0( *alpha ) ) return;
+
+	// If b_n is not equal to the fusing factor, then perform the entire
+	// operation as a loop over axpyv.
+	if ( b_n != fuse_fac )
+	{
+        if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+        axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DCOMPLEX, BLIS_AXPYV_KER, cntx );
+
+		for ( i = 0; i < b_n; ++i )
+		{
+			dcomplex* a1   = a + (0  )*inca + (i  )*lda;
+			dcomplex* chi1 = x + (i  )*incx;
+			dcomplex* y1   = y + (0  )*incy;
+			dcomplex  alpha_chi1;
+
+			bli_zcopycjs( conjx, *chi1, alpha_chi1 );
+			bli_zscals( *alpha, alpha_chi1 );
+
+			f
+				(
+				 conja,
+				 m,
+				 &alpha_chi1,
+				 a1, inca,
+				 y1, incy,
+				 cntx
+				);
+		}
+        
+		return;
+	}
+
+
+	// At this point, we know that b_n is exactly equal to the fusing factor.
+
+	a0   = a + 0*lda;
+	a1   = a + 1*lda;
+	a2   = a + 2*lda;
+	a3   = a + 3*lda;
+	a4   = a + 4*lda;
+	y0   = y;
+
+	chi0 = *( x + 0*incx );
+	chi1 = *( x + 1*incx );
+	chi2 = *( x + 2*incx );
+	chi3 = *( x + 3*incx );
+	chi4 = *( x + 4*incx );
+
+	dcomplex *pchi0 = x + 0*incx ;
+	dcomplex *pchi1 = x + 1*incx ;
+	dcomplex *pchi2 = x + 2*incx ;
+	dcomplex *pchi3 = x + 3*incx ;
+	dcomplex *pchi4 = x + 4*incx ;
+
+	bli_zcopycjs( conjx, *pchi0, chi0 );
+	bli_zcopycjs( conjx, *pchi1, chi1 );
+	bli_zcopycjs( conjx, *pchi2, chi2 );
+	bli_zcopycjs( conjx, *pchi3, chi3 );
+	bli_zcopycjs( conjx, *pchi4, chi4 );
+
+	// Scale each chi scalar by alpha.
+	bli_zscals( *alpha, chi0 );
+	bli_zscals( *alpha, chi1 );
+	bli_zscals( *alpha, chi2 );
+	bli_zscals( *alpha, chi3 );
+	bli_zscals( *alpha, chi4 );
+
+	// Broadcast the (alpha*chi?) scalars to all elements of vector registers.
+	chi0v.v = _mm256_broadcast_sd( &chi0.real );
+	chi1v.v = _mm256_broadcast_sd( &chi1.real );
+	chi2v.v = _mm256_broadcast_sd( &chi2.real );
+	chi3v.v = _mm256_broadcast_sd( &chi3.real );
+	chi4v.v = _mm256_broadcast_sd( &chi4.real );
+
+	chi5v.v = _mm256_broadcast_sd( &chi0.imag );
+	chi6v.v = _mm256_broadcast_sd( &chi1.imag );
+	chi7v.v = _mm256_broadcast_sd( &chi2.imag );
+	chi8v.v = _mm256_broadcast_sd( &chi3.imag );
+	chi9v.v = _mm256_broadcast_sd( &chi4.imag );
+
+	// If there are vectorized iterations, perform them with vector
+	// instructions.
+	if ( inca == 1 && incy == 1 )
+	{
+		// March through vectors in multiple of 4.
+		for( i = 0; (i + 3) < m; i += 4 )
+		{
+			// Load the input values.
+			r0v.v = _mm256_loadu_pd( (double*) (y0 + 0*n_elem_per_reg ));
+			r1v.v = _mm256_loadu_pd( (double*) (y0 + 1*n_elem_per_reg ));
+
+			y0v.v = _mm256_setzero_pd();
+			y1v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+			y3v.v = _mm256_setzero_pd();
+
+			if ( bli_is_conj(conja) ){
+				/**
+				 * For conjugate cases imaginary part
+				 * is negated.
+				 */
+				conjv.v = _mm256_set_pd( -1, 1, -1, 1 );
+				a00v.v = _mm256_loadu_pd( (double*) (a0 + 0*n_elem_per_reg ));
+				a10v.v = _mm256_loadu_pd( (double*) (a0 + 1*n_elem_per_reg ));
+
+				a01v.v = _mm256_loadu_pd( (double*) (a1 + 0*n_elem_per_reg ));
+				a11v.v = _mm256_loadu_pd( (double*) (a1 + 1*n_elem_per_reg ));
+
+				a02v.v = _mm256_loadu_pd( (double*) (a2 + 0*n_elem_per_reg ));
+				a12v.v = _mm256_loadu_pd( (double*) (a2 + 1*n_elem_per_reg ));
+
+				a03v.v = _mm256_loadu_pd( (double*) (a3 + 0*n_elem_per_reg ));
+				a13v.v = _mm256_loadu_pd( (double*) (a3 + 1*n_elem_per_reg ));
+
+				a04v.v = _mm256_loadu_pd( (double*) (a4 + 0*n_elem_per_reg ));
+				a14v.v = _mm256_loadu_pd( (double*) (a4 + 1*n_elem_per_reg ));
+
+				a00v.v = _mm256_mul_pd(a00v.v, conjv.v);
+				a10v.v = _mm256_mul_pd(a10v.v, conjv.v);
+				a01v.v = _mm256_mul_pd(a01v.v, conjv.v);
+				a11v.v = _mm256_mul_pd(a11v.v, conjv.v);
+				a02v.v = _mm256_mul_pd(a02v.v, conjv.v);
+				a12v.v = _mm256_mul_pd(a12v.v, conjv.v);
+				a03v.v = _mm256_mul_pd(a03v.v, conjv.v);
+				a13v.v = _mm256_mul_pd(a13v.v, conjv.v);
+				a04v.v = _mm256_mul_pd(a04v.v, conjv.v);
+				a14v.v = _mm256_mul_pd(a14v.v, conjv.v);
+			}
+			else
+			{
+				a00v.v = _mm256_loadu_pd( (double*) (a0 + 0*n_elem_per_reg ));
+				a10v.v = _mm256_loadu_pd( (double*) (a0 + 1*n_elem_per_reg ));
+
+				a01v.v = _mm256_loadu_pd( (double*) (a1 + 0*n_elem_per_reg ));
+				a11v.v = _mm256_loadu_pd( (double*) (a1 + 1*n_elem_per_reg ));
+
+				a02v.v = _mm256_loadu_pd( (double*) (a2 + 0*n_elem_per_reg ));
+				a12v.v = _mm256_loadu_pd( (double*) (a2 + 1*n_elem_per_reg ));
+
+				a03v.v = _mm256_loadu_pd( (double*) (a3 + 0*n_elem_per_reg ));
+				a13v.v = _mm256_loadu_pd( (double*) (a3 + 1*n_elem_per_reg ));
+
+				a04v.v = _mm256_loadu_pd( (double*) (a4 + 0*n_elem_per_reg ));
+				a14v.v = _mm256_loadu_pd( (double*) (a4 + 1*n_elem_per_reg ));
+
+			}
+
+			// perform : y += alpha * x;
+			/**
+			 * chi[x]v.v holds real part of chi.
+			 * chi[x]v.v holds imag part of chi.
+			 * ys holds following computation:
+			 *
+			 *   a[xx]v.v    R1        I1       R2         I2
+			 *  chi[x]v.v   chi_R     chi_R     chi_R      chi_R
+			 *  chi[x]v.v   chi_I     chi_I     chi_I      chi_I
+			 *    y[x]v.v   R1*chi_R  I1*chi_R  R2*chi_R  I2*chiR (compute with chi-real part)
+			 *    y[x]v.v   R1*chi_I  I1*chi_I  R2*chi_I  I2*chiI (compute with chi-imag part)
+			 *
+			 */
+			y0v.v = _mm256_mul_pd( a00v.v, chi0v.v);
+			y1v.v = _mm256_mul_pd( a10v.v, chi0v.v);
+
+			y2v.v = _mm256_mul_pd( a00v.v, chi5v.v);
+			y3v.v = _mm256_mul_pd( a10v.v, chi5v.v);
+
+			/**
+			 * y0v.v & y1v.v holds computation with real part of chi.
+			 * y2v.v & y3v.v holds computaion with imag part of chi.
+			 * Permute will swap the positions of elements in y2v.v & y3v.v
+			 * as we need to perform: [ R*R + I*I & R*I + I*R].
+			 * Once dcomplex multiplication is done add the result into r0v.v
+			 * r1v.v which holds axpy result of current tile which is being
+			 * computed.
+			 */
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y3v.v = _mm256_permute_pd(y3v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			y1v.v = _mm256_addsub_pd(y1v.v, y3v.v);
+
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+			r1v.v = _mm256_add_pd(y1v.v, r1v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y1v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+			y3v.v = _mm256_setzero_pd();
+
+			/**
+			 * Repeat the same computation as above
+			 * for remaining tile.
+			 */
+			y0v.v = _mm256_mul_pd( a01v.v, chi1v.v );
+			y1v.v = _mm256_mul_pd( a11v.v, chi1v.v );
+
+			y2v.v = _mm256_mul_pd( a01v.v, chi6v.v );
+			y3v.v = _mm256_mul_pd( a11v.v, chi6v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y3v.v = _mm256_permute_pd(y3v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			y1v.v = _mm256_addsub_pd(y1v.v, y3v.v);
+
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+			r1v.v = _mm256_add_pd(y1v.v, r1v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y1v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+			y3v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a02v.v, chi2v.v);
+			y1v.v = _mm256_mul_pd( a12v.v, chi2v.v);
+
+			y2v.v = _mm256_mul_pd( a02v.v, chi7v.v );
+			y3v.v = _mm256_mul_pd( a12v.v, chi7v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y3v.v = _mm256_permute_pd(y3v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			y1v.v = _mm256_addsub_pd(y1v.v, y3v.v);
+
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+			r1v.v = _mm256_add_pd(y1v.v, r1v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y1v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+			y3v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a03v.v, chi3v.v );
+			y1v.v = _mm256_mul_pd( a13v.v, chi3v.v );
+
+			y2v.v = _mm256_mul_pd( a03v.v, chi8v.v );
+			y3v.v = _mm256_mul_pd( a13v.v, chi8v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y3v.v = _mm256_permute_pd(y3v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			y1v.v = _mm256_addsub_pd(y1v.v, y3v.v);
+
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+			r1v.v = _mm256_add_pd(y1v.v, r1v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y1v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+			y3v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a04v.v, chi4v.v );
+			y1v.v = _mm256_mul_pd( a14v.v, chi4v.v );
+
+			y2v.v = _mm256_mul_pd( a04v.v, chi9v.v );
+			y3v.v = _mm256_mul_pd( a14v.v, chi9v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y3v.v = _mm256_permute_pd(y3v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			y1v.v = _mm256_addsub_pd(y1v.v, y3v.v);
+
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+			r1v.v = _mm256_add_pd(y1v.v, r1v.v);
+
+			/**
+			 * Final axpy compuation is available in r0v.v
+			 * and r1v.v registers.
+			 * Store it back into y vector.
+			 */
+			_mm256_storeu_pd( (double*) (y0 + 0*n_elem_per_reg), r0v.v );
+			_mm256_storeu_pd( (double*) (y0 + 1*n_elem_per_reg), r1v.v );
+
+			/**
+			 * Set the pointers next vectors elements to be
+			 * computed based on unroll factor.
+			 */
+			y0 += n_elem_per_reg * n_iter_unroll;
+			a0 += n_elem_per_reg * n_iter_unroll;
+			a1 += n_elem_per_reg * n_iter_unroll;
+			a2 += n_elem_per_reg * n_iter_unroll;
+			a3 += n_elem_per_reg * n_iter_unroll;
+			a4 += n_elem_per_reg * n_iter_unroll;
+		}
+		// March through vectors in multiple of 2.
+		for(  ; (i + 1) < m; i += 2 )
+		{
+			r0v.v = _mm256_loadu_pd( (double*) (y0 + 0*n_elem_per_reg ));
+
+			y0v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+
+			if ( bli_is_conj(conja) ){
+				conjv.v = _mm256_set_pd( -1, 1, -1, 1 );
+				a00v.v = _mm256_loadu_pd( (double*) (a0 + 0*n_elem_per_reg ));
+
+				a01v.v = _mm256_loadu_pd( (double*) (a1 + 0*n_elem_per_reg ));
+
+				a02v.v = _mm256_loadu_pd( (double*) (a2 + 0*n_elem_per_reg ));
+
+				a03v.v = _mm256_loadu_pd( (double*) (a3 + 0*n_elem_per_reg ));
+
+				a04v.v = _mm256_loadu_pd( (double*) (a4 + 0*n_elem_per_reg ));
+
+				a00v.v = _mm256_mul_pd(a00v.v, conjv.v);
+				a01v.v = _mm256_mul_pd(a01v.v, conjv.v);
+				a02v.v = _mm256_mul_pd(a02v.v, conjv.v);
+				a03v.v = _mm256_mul_pd(a03v.v, conjv.v);
+				a04v.v = _mm256_mul_pd(a04v.v, conjv.v);
+			}
+			else
+			{
+				a00v.v = _mm256_loadu_pd( (double*) (a0 + 0*n_elem_per_reg ));
+
+				a01v.v = _mm256_loadu_pd( (double*) (a1 + 0*n_elem_per_reg ));
+
+				a02v.v = _mm256_loadu_pd( (double*) (a2 + 0*n_elem_per_reg ));
+
+				a03v.v = _mm256_loadu_pd( (double*) (a3 + 0*n_elem_per_reg ));
+
+				a04v.v = _mm256_loadu_pd( (double*) (a4 + 0*n_elem_per_reg ));
+
+			}
+
+			// perform : y += alpha * x;
+			/**
+			 * chi[x]v.v holds real part of chi.
+			 * chi[x]v.v holds imag part of chi.
+			 * ys holds following computation:
+			 *
+			 *   a[xx]v.v    R1        I1       R2         I2
+			 *  chi[x]v.v   chi_R     chi_R     chi_R      chi_R
+			 *  chi[x]v.v   chi_I     chi_I     chi_I      chi_I
+			 *    y[x]v.v   R1*chi_R  I1*chi_R  R2*chi_R  I2*chiR (compute with chi-real part)
+			 *    y[x]v.v   R1*chi_I  I1*chi_I  R2*chi_I  I2*chiI (compute with chi-imag part)
+			 *
+			 */
+			y0v.v = _mm256_mul_pd( a00v.v, chi0v.v );
+			y2v.v = _mm256_mul_pd( a00v.v, chi5v.v );
+
+			/**
+			 * y0v.v holds computation with real part of chi.
+			 * y2v.v holds computaion with imag part of chi.
+			 * Permute will swap the positions of elements in y2v.v.
+			 * as we need to perform: [ R*R + I*I & R*I + I*R].
+			 * Once dcomplex multiplication is done add the result into r0v.v
+			 * which holds axpy result of current tile which is being
+			 * computed.
+			 */
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+
+			/**
+			 * Repeat the same computation as above
+			 * for remaining tile.
+			 */
+			y0v.v = _mm256_mul_pd( a01v.v, chi1v.v );
+			y2v.v = _mm256_mul_pd( a01v.v, chi6v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a02v.v, chi2v.v );
+			y2v.v = _mm256_mul_pd( a02v.v, chi7v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a03v.v, chi3v.v );
+			y2v.v = _mm256_mul_pd( a03v.v, chi8v.v );
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+
+			y0v.v = _mm256_setzero_pd();
+			y2v.v = _mm256_setzero_pd();
+
+
+			y0v.v = _mm256_mul_pd( a04v.v, chi4v.v );
+			y2v.v = _mm256_mul_pd( a04v.v, chi9v.v );
+
+
+			y2v.v = _mm256_permute_pd(y2v.v, 0x5);
+			y0v.v = _mm256_addsub_pd(y0v.v, y2v.v);
+			r0v.v = _mm256_add_pd(y0v.v, r0v.v);
+
+			/**
+			 * Final axpy compuation is available in r0v.v
+			 * Store it back into y vector.
+			 */
+			_mm256_storeu_pd( (double*) (y0 + 0*n_elem_per_reg), r0v.v );
+
+			y0 +=  n_iter_unroll;
+			a0 +=  n_iter_unroll;
+			a1 +=  n_iter_unroll;
+			a2 +=  n_iter_unroll;
+			a3 +=  n_iter_unroll;
+			a4 +=  n_iter_unroll;
+
+		}
+
+		// If there are leftover iterations, perform them with scalar code.
+		for ( ; (i + 0) < m ; ++i )
+		{
+			dcomplex       y0c = *y0;
+
+			const dcomplex a0c = *a0;
+			const dcomplex a1c = *a1;
+			const dcomplex a2c = *a2;
+			const dcomplex a3c = *a3;
+			const dcomplex a4c = *a4;
+
+			y0c.real += chi0.real * a0c.real - chi0.imag * a0c.imag * setPlusOne;
+			y0c.real += chi1.real * a1c.real - chi1.imag * a1c.imag * setPlusOne;
+			y0c.real += chi2.real * a2c.real - chi2.imag * a2c.imag * setPlusOne;
+			y0c.real += chi3.real * a3c.real - chi3.imag * a3c.imag * setPlusOne;
+			y0c.real += chi4.real * a4c.real - chi4.imag * a4c.imag * setPlusOne;
+
+			y0c.imag += chi0.imag * a0c.real + chi0.real * a0c.imag * setPlusOne;
+			y0c.imag += chi1.imag * a1c.real + chi1.real * a1c.imag * setPlusOne;
+			y0c.imag += chi2.imag * a2c.real + chi2.real * a2c.imag * setPlusOne;
+			y0c.imag += chi3.imag * a3c.real + chi3.real * a3c.imag * setPlusOne;
+			y0c.imag += chi4.imag * a4c.real + chi4.real * a4c.imag * setPlusOne;
+
+			*y0 = y0c;
+
+			a0 += 1;
+			a1 += 1;
+			a2 += 1;
+			a3 += 1;
+			a4 += 1;
+			y0 += 1;
+		}
+	}
+	else
+	{
+		for ( ; (i + 0) < m ; ++i )
+		{
+			dcomplex       y0c = *y0;
+
+			const dcomplex a0c = *a0;
+			const dcomplex a1c = *a1;
+			const dcomplex a2c = *a2;
+			const dcomplex a3c = *a3;
+			const dcomplex a4c = *a4;
+
+			y0c.real += chi0.real * a0c.real - chi0.imag * a0c.imag * setPlusOne;
+			y0c.real += chi1.real * a1c.real - chi1.imag * a1c.imag * setPlusOne;
+			y0c.real += chi2.real * a2c.real - chi2.imag * a2c.imag * setPlusOne;
+			y0c.real += chi3.real * a3c.real - chi3.imag * a3c.imag * setPlusOne;
+			y0c.real += chi4.real * a4c.real - chi4.imag * a4c.imag * setPlusOne;
+
+			y0c.imag += chi0.imag * a0c.real + chi0.real * a0c.imag * setPlusOne;
+			y0c.imag += chi1.imag * a1c.real + chi1.real * a1c.imag * setPlusOne;
+			y0c.imag += chi2.imag * a2c.real + chi2.real * a2c.imag * setPlusOne;
+			y0c.imag += chi3.imag * a3c.real + chi3.real * a3c.imag * setPlusOne;
+			y0c.imag += chi4.imag * a4c.real + chi4.real * a4c.imag * setPlusOne;
+
+			*y0 = y0c;
+
+			a0 += inca;
+			a1 += inca;
+			a2 += inca;
+			a3 += inca;
+			a4 += inca;
+			y0 += incy;
+		}
+
+	}
+}

--- a/kernels/zen/1f/bli_axpyf_zen_int_8.c
+++ b/kernels/zen/1f/bli_axpyf_zen_int_8.c
@@ -68,9 +68,9 @@ void bli_saxpyf_zen_int_8
      )
 {
 	const float* restrict alpha = (float *)alpha0;
-	const float* restrict a     = (float *)a00;
-	const float* restrict x     = (float *)x00;
-	      float* restrict y     = (float *)y00;
+	float* restrict a     = (float *)a00;
+	float* restrict x     = (float *)x00;
+	float* restrict y     = (float *)y00;
 
 	const dim_t      fuse_fac       = 8;
 	const dim_t      n_elem_per_reg = 8;
@@ -282,9 +282,9 @@ void bli_daxpyf_zen_int_8
      )
 {
 	const double* restrict alpha = (double *) alpha0;
-	const double* restrict a     = (double *) a00;
-	const double* restrict x     = (double *) x00;
-	      double* restrict y     = (double *) y00;
+	double* restrict a     = (double *) a00;
+	double* restrict x     = (double *) x00;
+	double* restrict y     = (double *) y00;
 
 	const dim_t      fuse_fac       = 8;
 	const dim_t      n_elem_per_reg = 4;

--- a/kernels/zen/1f/bli_axpyf_zen_int_8.c
+++ b/kernels/zen/1f/bli_axpyf_zen_int_8.c
@@ -5,7 +5,7 @@
    libraries.
 
    Copyright (C) 2018, The University of Texas at Austin
-   Copyright (C) 2016 - 2018, Advanced Micro Devices, Inc.
+   Copyright (C) 2016 - 2023, Advanced Micro Devices, Inc. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are
@@ -61,25 +61,35 @@ void bli_saxpyf_zen_int_8
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const float* restrict alpha = alpha0;
-	const float* restrict a     = a0;
-	const float* restrict x     = x0;
-	      float* restrict y     = y0;
+	const float* restrict alpha = (float *)alpha0;
+	const float* restrict a     = (float *)a00;
+	const float* restrict x     = (float *)x00;
+	      float* restrict y     = (float *)y00;
 
 	const dim_t      fuse_fac       = 8;
-
 	const dim_t      n_elem_per_reg = 8;
 	const dim_t      n_iter_unroll  = 1;
 
 	dim_t            i;
 	dim_t            m_viter;
 	dim_t            m_left;
+
+	float*  restrict a0;
+	float*  restrict a1;
+	float*  restrict a2;
+	float*  restrict a3;
+	float*  restrict a4;
+	float*  restrict a5;
+	float*  restrict a6;
+	float*  restrict a7;
+
+	float*  restrict y0;
 
 	v8sf_t           chi0v, chi1v, chi2v, chi3v;
 	v8sf_t           chi4v, chi5v, chi6v, chi7v;
@@ -98,14 +108,15 @@ void bli_saxpyf_zen_int_8
 	// operation as a loop over axpyv.
 	if ( b_n != fuse_fac )
 	{
-		axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_FLOAT, BLIS_AXPYV_KER, cntx );
+        if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+        axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_FLOAT, BLIS_AXPYV_KER, cntx );
 
 		for ( i = 0; i < b_n; ++i )
 		{
-			const float* restrict a1   = a + (0  )*inca + (i  )*lda;
-			const float* restrict chi1 = x + (i  )*incx;
-			      float* restrict y1   = y + (0  )*incy;
-			      float           alpha_chi1;
+			float* a1   = a + (0  )*inca + (i  )*lda;
+			float* chi1 = x + (i  )*incx;
+			float* y1   = y + (0  )*incy;
+			float  alpha_chi1;
 
 			PASTEMAC(s,copycjs)( conjx, *chi1, alpha_chi1 );
 			PASTEMAC(s,scals)( *alpha, alpha_chi1 );
@@ -140,24 +151,24 @@ void bli_saxpyf_zen_int_8
 		m_left  = m;
 	}
 
-	const float* restrict ap0   = a + 0*lda;
-	const float* restrict ap1   = a + 1*lda;
-	const float* restrict ap2   = a + 2*lda;
-	const float* restrict ap3   = a + 3*lda;
-	const float* restrict ap4   = a + 4*lda;
-	const float* restrict ap5   = a + 5*lda;
-	const float* restrict ap6   = a + 6*lda;
-	const float* restrict ap7   = a + 7*lda;
-	      float* restrict yp0   = y;
+	a0   = a + 0*lda;
+	a1   = a + 1*lda;
+	a2   = a + 2*lda;
+	a3   = a + 3*lda;
+	a4   = a + 4*lda;
+	a5   = a + 5*lda;
+	a6   = a + 6*lda;
+	a7   = a + 7*lda;
+	y0   = y;
 
-	chi0 = *( x + 0*incx );
-	chi1 = *( x + 1*incx );
-	chi2 = *( x + 2*incx );
-	chi3 = *( x + 3*incx );
-	chi4 = *( x + 4*incx );
-	chi5 = *( x + 5*incx );
-	chi6 = *( x + 6*incx );
-	chi7 = *( x + 7*incx );
+	chi0 = *( (float *)x + 0*incx );
+	chi1 = *( (float *)x + 1*incx );
+	chi2 = *( (float *)x + 2*incx );
+	chi3 = *( (float *)x + 3*incx );
+	chi4 = *( (float *)x + 4*incx );
+	chi5 = *( (float *)x + 5*incx );
+	chi6 = *( (float *)x + 6*incx );
+	chi7 = *( (float *)x + 7*incx );
 
 	// Scale each chi scalar by alpha.
 	PASTEMAC(s,scals)( *alpha, chi0 );
@@ -184,15 +195,15 @@ void bli_saxpyf_zen_int_8
 	for ( i = 0; i < m_viter; ++i )
 	{
 		// Load the input values.
-		y0v.v = _mm256_loadu_ps( yp0 + 0*n_elem_per_reg );
-		a0v.v = _mm256_loadu_ps( ap0 + 0*n_elem_per_reg );
-		a1v.v = _mm256_loadu_ps( ap1 + 0*n_elem_per_reg );
-		a2v.v = _mm256_loadu_ps( ap2 + 0*n_elem_per_reg );
-		a3v.v = _mm256_loadu_ps( ap3 + 0*n_elem_per_reg );
-		a4v.v = _mm256_loadu_ps( ap4 + 0*n_elem_per_reg );
-		a5v.v = _mm256_loadu_ps( ap5 + 0*n_elem_per_reg );
-		a6v.v = _mm256_loadu_ps( ap6 + 0*n_elem_per_reg );
-		a7v.v = _mm256_loadu_ps( ap7 + 0*n_elem_per_reg );
+		y0v.v = _mm256_loadu_ps( y0 + 0*n_elem_per_reg );
+		a0v.v = _mm256_loadu_ps( a0 + 0*n_elem_per_reg );
+		a1v.v = _mm256_loadu_ps( a1 + 0*n_elem_per_reg );
+		a2v.v = _mm256_loadu_ps( a2 + 0*n_elem_per_reg );
+		a3v.v = _mm256_loadu_ps( a3 + 0*n_elem_per_reg );
+		a4v.v = _mm256_loadu_ps( a4 + 0*n_elem_per_reg );
+		a5v.v = _mm256_loadu_ps( a5 + 0*n_elem_per_reg );
+		a6v.v = _mm256_loadu_ps( a6 + 0*n_elem_per_reg );
+		a7v.v = _mm256_loadu_ps( a7 + 0*n_elem_per_reg );
 
 		// perform : y += alpha * x;
 		y0v.v = _mm256_fmadd_ps( a0v.v, chi0v.v, y0v.v );
@@ -205,32 +216,32 @@ void bli_saxpyf_zen_int_8
 		y0v.v = _mm256_fmadd_ps( a7v.v, chi7v.v, y0v.v );
 
 		// Store the output.
-		_mm256_storeu_ps( (yp0 + 0*n_elem_per_reg), y0v.v );
+		_mm256_storeu_ps( (y0 + 0*n_elem_per_reg), y0v.v );
 
-		yp0 += n_elem_per_reg;
-		ap0 += n_elem_per_reg;
-		ap1 += n_elem_per_reg;
-		ap2 += n_elem_per_reg;
-		ap3 += n_elem_per_reg;
-		ap4 += n_elem_per_reg;
-		ap5 += n_elem_per_reg;
-		ap6 += n_elem_per_reg;
-		ap7 += n_elem_per_reg;
+		y0 += n_elem_per_reg;
+		a0 += n_elem_per_reg;
+		a1 += n_elem_per_reg;
+		a2 += n_elem_per_reg;
+		a3 += n_elem_per_reg;
+		a4 += n_elem_per_reg;
+		a5 += n_elem_per_reg;
+		a6 += n_elem_per_reg;
+		a7 += n_elem_per_reg;
 	}
 
 	// If there are leftover iterations, perform them with scalar code.
 	for ( i = 0; i < m_left ; ++i )
 	{
-		float       y0c = *yp0;
+		float       y0c = *y0;
 
-		const float a0c = *ap0;
-		const float a1c = *ap1;
-		const float a2c = *ap2;
-		const float a3c = *ap3;
-		const float a4c = *ap4;
-		const float a5c = *ap5;
-		const float a6c = *ap6;
-		const float a7c = *ap7;
+		const float a0c = *a0;
+		const float a1c = *a1;
+		const float a2c = *a2;
+		const float a3c = *a3;
+		const float a4c = *a4;
+		const float a5c = *a5;
+		const float a6c = *a6;
+		const float a7c = *a7;
 
 		y0c += chi0 * a0c;
 		y0c += chi1 * a1c;
@@ -241,17 +252,17 @@ void bli_saxpyf_zen_int_8
 		y0c += chi6 * a6c;
 		y0c += chi7 * a7c;
 
-		*yp0 = y0c;
+		*y0 = y0c;
 
-		ap0 += inca;
-		ap1 += inca;
-		ap2 += inca;
-		ap3 += inca;
-		ap4 += inca;
-		ap5 += inca;
-		ap6 += inca;
-		ap7 += inca;
-		yp0 += incy;
+		a0 += inca;
+		a1 += inca;
+		a2 += inca;
+		a3 += inca;
+		a4 += inca;
+		a5 += inca;
+		a6 += inca;
+		a7 += inca;
+		y0 += incy;
 	}
 }
 
@@ -264,54 +275,152 @@ void bli_daxpyf_zen_int_8
              dim_t   m,
              dim_t   b_n,
        const void*   alpha0,
-       const void*   a0, inc_t inca, inc_t lda,
-       const void*   x0, inc_t incx,
-             void*   y0, inc_t incy,
+       const void*   a00, inc_t inca, inc_t lda,
+       const void*   x00, inc_t incx,
+             void*   y00, inc_t incy,
        const cntx_t* cntx
      )
 {
-	const double* restrict alpha = alpha0;
-	const double* restrict a     = a0;
-	const double* restrict x     = x0;
-	      double* restrict y     = y0;
+	const double* restrict alpha = (double *) alpha0;
+	const double* restrict a     = (double *) a00;
+	const double* restrict x     = (double *) x00;
+	      double* restrict y     = (double *) y00;
 
 	const dim_t      fuse_fac       = 8;
-
 	const dim_t      n_elem_per_reg = 4;
-	const dim_t      n_iter_unroll  = 1;
+	const dim_t      n_iter_unroll[4]  = {4, 3, 2, 1};
 
 	dim_t            i;
-	dim_t            m_viter;
-	dim_t            m_left;
+	dim_t            m_viter[4];
+	dim_t            m_left = m;
 
-	v4df_t           chi0v, chi1v, chi2v, chi3v;
-	v4df_t           chi4v, chi5v, chi6v, chi7v;
+	double* restrict av[8] __attribute__((aligned(64)));
 
-	v4df_t           a0v, a1v, a2v, a3v;
-	v4df_t           a4v, a5v, a6v, a7v;
-	v4df_t           y0v;
+	double* restrict y0;
 
-	double           chi0, chi1, chi2, chi3;
-	double           chi4, chi5, chi6, chi7;
+	v4df_t           chiv[8], a_vec[32], yv[4];
+
+	double           chi[8] __attribute__((aligned(64)));
 
 	// If either dimension is zero, or if alpha is zero, return early.
 	if ( bli_zero_dim2( m, b_n ) || PASTEMAC(d,eq0)( *alpha ) ) return;
 
-	// If b_n is not equal to the fusing factor, then perform the entire
-	// operation as a loop over axpyv.
-	if ( b_n != fuse_fac )
+	/*
+	  If b_n is not equal to the fusing factor, then perform the entire
+	  operation as axpyv or perform the operation using axpyf kernels with
+	  lower fuse factor.
+	*/
+	if ( b_n < fuse_fac )
 	{
-		axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
-
-		for ( i = 0; i < b_n; ++i )
+		if (b_n >= 5)
 		{
-			const double* restrict a1   = a + (0  )*inca + (i  )*lda;
-			const double* restrict chi1 = x + (i  )*incx;
-			      double* restrict y1   = y + (0  )*incy;
-			      double           alpha_chi1;
+			dim_t fuse_fac = 5;
+
+			bli_daxpyf_zen_int_5
+			(
+			  conja,
+			  conjx,
+			  m,
+			  fuse_fac,
+			  alpha,
+			  a, inca, lda,
+			  x, incx,
+			  y, incy,
+			  cntx
+			);
+
+			a = a + (fuse_fac * lda);
+			x = x + (fuse_fac * incx);
+
+			b_n -= fuse_fac;
+		}
+
+		if (b_n == 4)
+		{
+			dim_t fuse_fac = 4;
+
+			bli_daxpyf_zen_int_16x4
+			(
+			  conja,
+			  conjx,
+			  m,
+			  fuse_fac,
+			  alpha,
+			  a, inca, lda,
+			  x, incx,
+			  y, incy,
+			  cntx
+			);
+
+			a = a + (fuse_fac * lda);
+			x = x + (fuse_fac * incx);
+
+			b_n -= fuse_fac;
+		}
+
+		if (b_n >= 2)
+		{
+			dim_t fuse_fac = 2;
+
+			bli_daxpyf_zen_int_16x2
+			(
+			  conja,
+			  conjx,
+			  m, fuse_fac,
+			  alpha, a, inca, lda,
+			  x, incx,
+			  y, incy,
+			  cntx
+			);
+
+			a = a + (fuse_fac * lda);
+			x = x + (fuse_fac * incx);
+
+			b_n -= fuse_fac;
+
+		}
+
+		if (b_n == 1)
+		{
+			// Query the context if it is NULL. This will be necessary for Zen architectures
+        	if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+        	axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
+
+			double* a1   = a;
+			double* chi1 = x;
+			double* y1   = y;
+			double  alpha_chi1;
 
 			PASTEMAC(d,copycjs)( conjx, *chi1, alpha_chi1 );
 			PASTEMAC(d,scals)( *alpha, alpha_chi1 );
+
+			f
+			(
+			  conja,
+			  m,
+			  &alpha_chi1,
+			  a1, inca,
+			  y1, incy,
+			  cntx
+			);
+		}
+
+		return;
+	}
+	else if ( b_n > fuse_fac )
+	{
+        if ( cntx == NULL ) cntx = ( cntx_t* )bli_gks_query_cntx();
+        axpyv_ker_ft f = bli_cntx_get_ukr_dt( BLIS_DOUBLE, BLIS_AXPYV_KER, cntx );
+
+		for ( i = 0; i < b_n; ++i )
+		{
+			double* a1   = a + (0  )*inca + (i  )*lda;
+			double* chi1 = x + (i  )*incx;
+			double* y1   = y + (0  )*incy;
+			double  alpha_chi1;
+
+			bli_dcopycjs( conjx, *chi1, alpha_chi1 );
+			bli_dscals( *alpha, alpha_chi1 );
 
 			f
 			(
@@ -331,130 +440,378 @@ void bli_daxpyf_zen_int_8
 
 	// Use the unrolling factor and the number of elements per register
 	// to compute the number of vectorized and leftover iterations.
-	m_viter = ( m ) / ( n_elem_per_reg * n_iter_unroll );
-	m_left  = ( m ) % ( n_elem_per_reg * n_iter_unroll );
+	m_viter[0] = ( m_left ) / ( n_elem_per_reg * n_iter_unroll[0] );
+	m_left  = ( m_left ) % ( n_elem_per_reg * n_iter_unroll[0] );
+
+	m_viter[1] = ( m_left ) / ( n_elem_per_reg * n_iter_unroll[1] );
+	m_left  = ( m_left ) % ( n_elem_per_reg * n_iter_unroll[1] );
+
+	m_viter[2] = ( m_left ) / ( n_elem_per_reg * n_iter_unroll[2] );
+	m_left  = ( m_left ) % ( n_elem_per_reg * n_iter_unroll[2] );
+
+	m_viter[3] = ( m_left ) / ( n_elem_per_reg * n_iter_unroll[3] );
+	m_left  = ( m_left ) % ( n_elem_per_reg * n_iter_unroll[3] );
 
 	// If there is anything that would interfere with our use of contiguous
 	// vector loads/stores, override m_viter and m_left to use scalar code
 	// for all iterations.
 	if ( inca != 1 || incy != 1 )
 	{
-		m_viter = 0;
+		m_viter[0] = m_viter[1] = m_viter[2] = m_viter[3] = 0;
 		m_left  = m;
 	}
 
-	const double* restrict ap0   = a + 0*lda;
-	const double* restrict ap1   = a + 1*lda;
-	const double* restrict ap2   = a + 2*lda;
-	const double* restrict ap3   = a + 3*lda;
-	const double* restrict ap4   = a + 4*lda;
-	const double* restrict ap5   = a + 5*lda;
-	const double* restrict ap6   = a + 6*lda;
-	const double* restrict ap7   = a + 7*lda;
-	      double* restrict yp0   = y;
+	// av points to the 8 columns under consideration
+	av[0]   = a + 0*lda;
+	av[1]   = a + 1*lda;
+	av[2]   = a + 2*lda;
+	av[3]   = a + 3*lda;
+	av[4]   = a + 4*lda;
+	av[5]   = a + 5*lda;
+	av[6]   = a + 6*lda;
+	av[7]   = a + 7*lda;
+	y0   = y;
 
-	chi0 = *( x + 0*incx );
-	chi1 = *( x + 1*incx );
-	chi2 = *( x + 2*incx );
-	chi3 = *( x + 3*incx );
-	chi4 = *( x + 4*incx );
-	chi5 = *( x + 5*incx );
-	chi6 = *( x + 6*incx );
-	chi7 = *( x + 7*incx );
+	chi[0] = *( x + 0*incx );
+	chi[1] = *( x + 1*incx );
+	chi[2] = *( x + 2*incx );
+	chi[3] = *( x + 3*incx );
+	chi[4] = *( x + 4*incx );
+	chi[5] = *( x + 5*incx );
+	chi[6] = *( x + 6*incx );
+	chi[7] = *( x + 7*incx );
 
 	// Scale each chi scalar by alpha.
-	PASTEMAC(d,scals)( *alpha, chi0 );
-	PASTEMAC(d,scals)( *alpha, chi1 );
-	PASTEMAC(d,scals)( *alpha, chi2 );
-	PASTEMAC(d,scals)( *alpha, chi3 );
-	PASTEMAC(d,scals)( *alpha, chi4 );
-	PASTEMAC(d,scals)( *alpha, chi5 );
-	PASTEMAC(d,scals)( *alpha, chi6 );
-	PASTEMAC(d,scals)( *alpha, chi7 );
+	PASTEMAC(d,scals)( *alpha, chi[0] );
+	PASTEMAC(d,scals)( *alpha, chi[1] );
+	PASTEMAC(d,scals)( *alpha, chi[2] );
+	PASTEMAC(d,scals)( *alpha, chi[3] );
+	PASTEMAC(d,scals)( *alpha, chi[4] );
+	PASTEMAC(d,scals)( *alpha, chi[5] );
+	PASTEMAC(d,scals)( *alpha, chi[6] );
+	PASTEMAC(d,scals)( *alpha, chi[7] );
 
 	// Broadcast the (alpha*chi?) scalars to all elements of vector registers.
-	chi0v.v = _mm256_broadcast_sd( &chi0 );
-	chi1v.v = _mm256_broadcast_sd( &chi1 );
-	chi2v.v = _mm256_broadcast_sd( &chi2 );
-	chi3v.v = _mm256_broadcast_sd( &chi3 );
-	chi4v.v = _mm256_broadcast_sd( &chi4 );
-	chi5v.v = _mm256_broadcast_sd( &chi5 );
-	chi6v.v = _mm256_broadcast_sd( &chi6 );
-	chi7v.v = _mm256_broadcast_sd( &chi7 );
+	chiv[0].v = _mm256_broadcast_sd( &chi[0] );
+	chiv[1].v = _mm256_broadcast_sd( &chi[1] );
+	chiv[2].v = _mm256_broadcast_sd( &chi[2] );
+	chiv[3].v = _mm256_broadcast_sd( &chi[3] );
+	chiv[4].v = _mm256_broadcast_sd( &chi[4] );
+	chiv[5].v = _mm256_broadcast_sd( &chi[5] );
+	chiv[6].v = _mm256_broadcast_sd( &chi[6] );
+	chiv[7].v = _mm256_broadcast_sd( &chi[7] );
 
 	// If there are vectorized iterations, perform them with vector
 	// instructions.
-	for ( i = 0; i < m_viter; ++i )
+	// 16 elements of the result are computed per iteration
+	for ( i = 0; i < m_viter[0]; ++i )
 	{
 		// Load the input values.
-		y0v.v = _mm256_loadu_pd( yp0 + 0*n_elem_per_reg );
-		a0v.v = _mm256_loadu_pd( ap0 + 0*n_elem_per_reg );
-		a1v.v = _mm256_loadu_pd( ap1 + 0*n_elem_per_reg );
-		a2v.v = _mm256_loadu_pd( ap2 + 0*n_elem_per_reg );
-		a3v.v = _mm256_loadu_pd( ap3 + 0*n_elem_per_reg );
-		a4v.v = _mm256_loadu_pd( ap4 + 0*n_elem_per_reg );
-		a5v.v = _mm256_loadu_pd( ap5 + 0*n_elem_per_reg );
-		a6v.v = _mm256_loadu_pd( ap6 + 0*n_elem_per_reg );
-		a7v.v = _mm256_loadu_pd( ap7 + 0*n_elem_per_reg );
+		yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+		yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+		yv[2].v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+		yv[3].v = _mm256_loadu_pd( y0 + 3*n_elem_per_reg );
+
+		a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+		a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+		a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+		a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+		a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+		a_vec[5].v = _mm256_loadu_pd( av[5] + 0*n_elem_per_reg );
+		a_vec[6].v = _mm256_loadu_pd( av[6] + 0*n_elem_per_reg );
+		a_vec[7].v = _mm256_loadu_pd( av[7] + 0*n_elem_per_reg );
+		
+		a_vec[8].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+		a_vec[9].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+		a_vec[10].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+		a_vec[11].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+		a_vec[12].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
+		a_vec[13].v = _mm256_loadu_pd( av[5] + 1*n_elem_per_reg );
+		a_vec[14].v = _mm256_loadu_pd( av[6] + 1*n_elem_per_reg );
+		a_vec[15].v = _mm256_loadu_pd( av[7] + 1*n_elem_per_reg );
+
+		a_vec[16].v = _mm256_loadu_pd( av[0] + 2*n_elem_per_reg );
+		a_vec[17].v = _mm256_loadu_pd( av[1] + 2*n_elem_per_reg );
+		a_vec[18].v = _mm256_loadu_pd( av[2] + 2*n_elem_per_reg );
+		a_vec[19].v = _mm256_loadu_pd( av[3] + 2*n_elem_per_reg );
+		a_vec[20].v = _mm256_loadu_pd( av[4] + 2*n_elem_per_reg );
+		a_vec[21].v = _mm256_loadu_pd( av[5] + 2*n_elem_per_reg );
+		a_vec[22].v = _mm256_loadu_pd( av[6] + 2*n_elem_per_reg );
+		a_vec[23].v = _mm256_loadu_pd( av[7] + 2*n_elem_per_reg );
+
+		a_vec[24].v = _mm256_loadu_pd( av[0] + 3*n_elem_per_reg );
+		a_vec[25].v = _mm256_loadu_pd( av[1] + 3*n_elem_per_reg );
+		a_vec[26].v = _mm256_loadu_pd( av[2] + 3*n_elem_per_reg );
+		a_vec[27].v = _mm256_loadu_pd( av[3] + 3*n_elem_per_reg );
+		a_vec[28].v = _mm256_loadu_pd( av[4] + 3*n_elem_per_reg );
+		a_vec[29].v = _mm256_loadu_pd( av[5] + 3*n_elem_per_reg );
+		a_vec[30].v = _mm256_loadu_pd( av[6] + 3*n_elem_per_reg );
+		a_vec[31].v = _mm256_loadu_pd( av[7] + 3*n_elem_per_reg );
 
 		// perform : y += alpha * x;
-		y0v.v = _mm256_fmadd_pd( a0v.v, chi0v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a1v.v, chi1v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a2v.v, chi2v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a3v.v, chi3v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a4v.v, chi4v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a5v.v, chi5v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a6v.v, chi6v.v, y0v.v );
-		y0v.v = _mm256_fmadd_pd( a7v.v, chi7v.v, y0v.v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[5].v, chiv[5].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[6].v, chiv[6].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[7].v, chiv[7].v, yv[0].v );
+
+		yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[0].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[1].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[10].v, chiv[2].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[11].v, chiv[3].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[12].v, chiv[4].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[13].v, chiv[5].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[14].v, chiv[6].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[15].v, chiv[7].v, yv[1].v );
+
+		yv[2].v = _mm256_fmadd_pd( a_vec[16].v, chiv[0].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[17].v, chiv[1].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[18].v, chiv[2].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[19].v, chiv[3].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[20].v, chiv[4].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[21].v, chiv[5].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[22].v, chiv[6].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[23].v, chiv[7].v, yv[2].v );
+
+		yv[3].v = _mm256_fmadd_pd( a_vec[24].v, chiv[0].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[25].v, chiv[1].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[26].v, chiv[2].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[27].v, chiv[3].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[28].v, chiv[4].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[29].v, chiv[5].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[30].v, chiv[6].v, yv[3].v );
+		yv[3].v = _mm256_fmadd_pd( a_vec[31].v, chiv[7].v, yv[3].v );
 
 		// Store the output.
-		_mm256_storeu_pd( (yp0 + 0*n_elem_per_reg), y0v.v );
+		_mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+		_mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+		_mm256_storeu_pd( (y0 + 2*n_elem_per_reg), yv[2].v );
+		_mm256_storeu_pd( (y0 + 3*n_elem_per_reg), yv[3].v );
 
-		yp0 += n_elem_per_reg;
-		ap0 += n_elem_per_reg;
-		ap1 += n_elem_per_reg;
-		ap2 += n_elem_per_reg;
-		ap3 += n_elem_per_reg;
-		ap4 += n_elem_per_reg;
-		ap5 += n_elem_per_reg;
-		ap6 += n_elem_per_reg;
-		ap7 += n_elem_per_reg;
+		y0 += n_elem_per_reg * n_iter_unroll[0];
+		av[0] += n_elem_per_reg * n_iter_unroll[0];
+		av[1] += n_elem_per_reg * n_iter_unroll[0];
+		av[2] += n_elem_per_reg * n_iter_unroll[0];
+		av[3] += n_elem_per_reg * n_iter_unroll[0];
+		av[4] += n_elem_per_reg * n_iter_unroll[0];
+		av[5] += n_elem_per_reg * n_iter_unroll[0];
+		av[6] += n_elem_per_reg * n_iter_unroll[0];
+		av[7] += n_elem_per_reg * n_iter_unroll[0];
+	}
+
+	// 12 elements of the result are computed per iteration
+	for ( i = 0; i < m_viter[1]; ++i )
+	{
+		// Load the input values.
+		yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+		yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+		yv[2].v = _mm256_loadu_pd( y0 + 2*n_elem_per_reg );
+
+		a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+		a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+		a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+		a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+		a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+		a_vec[5].v = _mm256_loadu_pd( av[5] + 0*n_elem_per_reg );
+		a_vec[6].v = _mm256_loadu_pd( av[6] + 0*n_elem_per_reg );
+		a_vec[7].v = _mm256_loadu_pd( av[7] + 0*n_elem_per_reg );
+		
+		a_vec[8].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+		a_vec[9].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+		a_vec[10].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+		a_vec[11].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+		a_vec[12].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
+		a_vec[13].v = _mm256_loadu_pd( av[5] + 1*n_elem_per_reg );
+		a_vec[14].v = _mm256_loadu_pd( av[6] + 1*n_elem_per_reg );
+		a_vec[15].v = _mm256_loadu_pd( av[7] + 1*n_elem_per_reg );
+
+		a_vec[16].v = _mm256_loadu_pd( av[0] + 2*n_elem_per_reg );
+		a_vec[17].v = _mm256_loadu_pd( av[1] + 2*n_elem_per_reg );
+		a_vec[18].v = _mm256_loadu_pd( av[2] + 2*n_elem_per_reg );
+		a_vec[19].v = _mm256_loadu_pd( av[3] + 2*n_elem_per_reg );
+		a_vec[20].v = _mm256_loadu_pd( av[4] + 2*n_elem_per_reg );
+		a_vec[21].v = _mm256_loadu_pd( av[5] + 2*n_elem_per_reg );
+		a_vec[22].v = _mm256_loadu_pd( av[6] + 2*n_elem_per_reg );
+		a_vec[23].v = _mm256_loadu_pd( av[7] + 2*n_elem_per_reg );
+
+		// perform : y += alpha * x;
+		yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[5].v, chiv[5].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[6].v, chiv[6].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[7].v, chiv[7].v, yv[0].v );
+
+		yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[0].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[1].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[10].v, chiv[2].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[11].v, chiv[3].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[12].v, chiv[4].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[13].v, chiv[5].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[14].v, chiv[6].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[15].v, chiv[7].v, yv[1].v );
+
+		yv[2].v = _mm256_fmadd_pd( a_vec[16].v, chiv[0].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[17].v, chiv[1].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[18].v, chiv[2].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[19].v, chiv[3].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[20].v, chiv[4].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[21].v, chiv[5].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[22].v, chiv[6].v, yv[2].v );
+		yv[2].v = _mm256_fmadd_pd( a_vec[23].v, chiv[7].v, yv[2].v );
+
+		// Store the output.
+		_mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+		_mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+		_mm256_storeu_pd( (y0 + 2*n_elem_per_reg), yv[2].v );
+
+		y0 += n_elem_per_reg * n_iter_unroll[1];
+		av[0] += n_elem_per_reg * n_iter_unroll[1];
+		av[1] += n_elem_per_reg * n_iter_unroll[1];
+		av[2] += n_elem_per_reg * n_iter_unroll[1];
+		av[3] += n_elem_per_reg * n_iter_unroll[1];
+		av[4] += n_elem_per_reg * n_iter_unroll[1];
+		av[5] += n_elem_per_reg * n_iter_unroll[1];
+		av[6] += n_elem_per_reg * n_iter_unroll[1];
+		av[7] += n_elem_per_reg * n_iter_unroll[1];
+	}
+
+	// 8 elements of the result are computed per iteration
+	for ( i = 0; i < m_viter[2]; ++i )
+	{
+		// Load the input values.
+		yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+		yv[1].v = _mm256_loadu_pd( y0 + 1*n_elem_per_reg );
+
+		a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+		a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+		a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+		a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+		a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+		a_vec[5].v = _mm256_loadu_pd( av[5] + 0*n_elem_per_reg );
+		a_vec[6].v = _mm256_loadu_pd( av[6] + 0*n_elem_per_reg );
+		a_vec[7].v = _mm256_loadu_pd( av[7] + 0*n_elem_per_reg );
+		
+		a_vec[8].v = _mm256_loadu_pd( av[0] + 1*n_elem_per_reg );
+		a_vec[9].v = _mm256_loadu_pd( av[1] + 1*n_elem_per_reg );
+		a_vec[10].v = _mm256_loadu_pd( av[2] + 1*n_elem_per_reg );
+		a_vec[11].v = _mm256_loadu_pd( av[3] + 1*n_elem_per_reg );
+		a_vec[12].v = _mm256_loadu_pd( av[4] + 1*n_elem_per_reg );
+		a_vec[13].v = _mm256_loadu_pd( av[5] + 1*n_elem_per_reg );
+		a_vec[14].v = _mm256_loadu_pd( av[6] + 1*n_elem_per_reg );
+		a_vec[15].v = _mm256_loadu_pd( av[7] + 1*n_elem_per_reg );
+
+		// perform : y += alpha * x;
+		yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[5].v, chiv[5].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[6].v, chiv[6].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[7].v, chiv[7].v, yv[0].v );
+
+		yv[1].v = _mm256_fmadd_pd( a_vec[8].v, chiv[0].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[9].v, chiv[1].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[10].v, chiv[2].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[11].v, chiv[3].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[12].v, chiv[4].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[13].v, chiv[5].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[14].v, chiv[6].v, yv[1].v );
+		yv[1].v = _mm256_fmadd_pd( a_vec[15].v, chiv[7].v, yv[1].v );
+
+		// Store the output.
+		_mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+		_mm256_storeu_pd( (y0 + 1*n_elem_per_reg), yv[1].v );
+
+		y0 += n_elem_per_reg * n_iter_unroll[2];
+		av[0] += n_elem_per_reg * n_iter_unroll[2];
+		av[1] += n_elem_per_reg * n_iter_unroll[2];
+		av[2] += n_elem_per_reg * n_iter_unroll[2];
+		av[3] += n_elem_per_reg * n_iter_unroll[2];
+		av[4] += n_elem_per_reg * n_iter_unroll[2];
+		av[5] += n_elem_per_reg * n_iter_unroll[2];
+		av[6] += n_elem_per_reg * n_iter_unroll[2];
+		av[7] += n_elem_per_reg * n_iter_unroll[2];
+	}
+
+	// 4 elements of the result are computed per iteration
+	for ( i = 0; i < m_viter[3]; ++i )
+	{
+		// Load the input values.
+		yv[0].v = _mm256_loadu_pd( y0 + 0*n_elem_per_reg );
+
+		a_vec[0].v = _mm256_loadu_pd( av[0] + 0*n_elem_per_reg );
+		a_vec[1].v = _mm256_loadu_pd( av[1] + 0*n_elem_per_reg );
+		a_vec[2].v = _mm256_loadu_pd( av[2] + 0*n_elem_per_reg );
+		a_vec[3].v = _mm256_loadu_pd( av[3] + 0*n_elem_per_reg );
+		a_vec[4].v = _mm256_loadu_pd( av[4] + 0*n_elem_per_reg );
+		a_vec[5].v = _mm256_loadu_pd( av[5] + 0*n_elem_per_reg );
+		a_vec[6].v = _mm256_loadu_pd( av[6] + 0*n_elem_per_reg );
+		a_vec[7].v = _mm256_loadu_pd( av[7] + 0*n_elem_per_reg );
+
+		// perform : y += alpha * x;
+		yv[0].v = _mm256_fmadd_pd( a_vec[0].v, chiv[0].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[1].v, chiv[1].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[2].v, chiv[2].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[3].v, chiv[3].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[4].v, chiv[4].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[5].v, chiv[5].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[6].v, chiv[6].v, yv[0].v );
+		yv[0].v = _mm256_fmadd_pd( a_vec[7].v, chiv[7].v, yv[0].v );
+
+		// Store the output.
+		_mm256_storeu_pd( (y0 + 0*n_elem_per_reg), yv[0].v );
+
+		y0 += n_elem_per_reg;
+		av[0] += n_elem_per_reg;
+		av[1] += n_elem_per_reg;
+		av[2] += n_elem_per_reg;
+		av[3] += n_elem_per_reg;
+		av[4] += n_elem_per_reg;
+		av[5] += n_elem_per_reg;
+		av[6] += n_elem_per_reg;
+		av[7] += n_elem_per_reg;
 	}
 
 	// If there are leftover iterations, perform them with scalar code.
 	for ( i = 0; i < m_left ; ++i )
 	{
-		double       y0c = *yp0;
+		double       y0c = *y0;
 
-		const double a0c = *ap0;
-		const double a1c = *ap1;
-		const double a2c = *ap2;
-		const double a3c = *ap3;
-		const double a4c = *ap4;
-		const double a5c = *ap5;
-		const double a6c = *ap6;
-		const double a7c = *ap7;
+		const double a0c = *av[0];
+		const double a1c = *av[1];
+		const double a2c = *av[2];
+		const double a3c = *av[3];
+		const double a4c = *av[4];
+		const double a5c = *av[5];
+		const double a6c = *av[6];
+		const double a7c = *av[7];
 
-		y0c += chi0 * a0c;
-		y0c += chi1 * a1c;
-		y0c += chi2 * a2c;
-		y0c += chi3 * a3c;
-		y0c += chi4 * a4c;
-		y0c += chi5 * a5c;
-		y0c += chi6 * a6c;
-		y0c += chi7 * a7c;
+		y0c += chi[0] * a0c;
+		y0c += chi[1] * a1c;
+		y0c += chi[2] * a2c;
+		y0c += chi[3] * a3c;
+		y0c += chi[4] * a4c;
+		y0c += chi[5] * a5c;
+		y0c += chi[6] * a6c;
+		y0c += chi[7] * a7c;
 
-		*yp0 = y0c;
+		*y0 = y0c;
 
-		ap0 += inca;
-		ap1 += inca;
-		ap2 += inca;
-		ap3 += inca;
-		ap4 += inca;
-		ap5 += inca;
-		ap6 += inca;
-		ap7 += inca;
-		yp0 += incy;
+		av[0] += inca;
+		av[1] += inca;
+		av[2] += inca;
+		av[3] += inca;
+		av[4] += inca;
+		av[5] += inca;
+		av[6] += inca;
+		av[7] += inca;
+		y0 += incy;
 	}
 }
-

--- a/kernels/zen/bli_kernels_zen.h
+++ b/kernels/zen/bli_kernels_zen.h
@@ -51,9 +51,10 @@ AXPYV_KER_PROT( float,    s, axpyv_zen_int )
 AXPYV_KER_PROT( double,   d, axpyv_zen_int )
 
 // axpyv (intrinsics unrolled x10)
-AXPYV_KER_PROT( float,    s, axpyv_zen_int10 )
-AXPYV_KER_PROT( double,   d, axpyv_zen_int10 )
-
+AXPYV_KER_PROT( float,    s, axpyv_zen_int_10 )
+AXPYV_KER_PROT( double,   d, axpyv_zen_int_10 )
+AXPYV_KER_PROT( scomplex, c, axpyv_zen_int_5 )
+AXPYV_KER_PROT( dcomplex, z, axpyv_zen_int_5 )
 // dotv (intrinsics)
 DOTV_KER_PROT( float,    s, dotv_zen_int )
 DOTV_KER_PROT( double,   d, dotv_zen_int )
@@ -101,6 +102,7 @@ AXPYF_KER_PROT( float,    s, axpyf_zen_int_5 )
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_5 )
 
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_16x4 )
+AXPYF_KER_PROT( double,   d, axpyf_zen_int_16x2 )
 AXPYF_KER_PROT( scomplex, c, axpyf_zen_int_4 )
 
 // dotxf (intrinsics)

--- a/kernels/zen/bli_kernels_zen.h
+++ b/kernels/zen/bli_kernels_zen.h
@@ -100,6 +100,8 @@ AXPYF_KER_PROT( float,    s, axpyf_zen_int_8 )
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_8 )
 AXPYF_KER_PROT( float,    s, axpyf_zen_int_5 )
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_5 )
+AXPYF_KER_PROT( scomplex,    c, axpyf_zen_int_5 )
+AXPYF_KER_PROT( dcomplex,   z, axpyf_zen_int_5 )
 
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_16x4 )
 AXPYF_KER_PROT( double,   d, axpyf_zen_int_16x2 )


### PR DESCRIPTION
- Implemented new AVX2 AXPYV kernels for complex (c) and double complex (z) data types.
- Added a new AXPYF kernel with fuse_factor = 4 and iter_unroll = 4 to improve performance.
- Updated kernel registration to include the new implementations.